### PR TITLE
Remove the static certificates from the docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ FROM alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef
 WORKDIR /
 RUN mkdir /certs
 COPY --from=builder /tmp/aaop/aaop .
-COPY --from=builder /tmp/aaop/certs/tls.crt /tmp/aaop/certs/tls.key /certs/
 
 USER 65532:65532
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,25 @@ $ helm install gatekeeper/gatekeeper \
     --create-namespace
 ```
 
-1. Generate server TLS for the external data provider
+1. Generate server TLS for the external data provider and load them
+   into secrets
 
 ```
 $ ./scripts/gen_certs.sh
+```
+
+```
+$ cat cert-secrets.yaml
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: provider-tls-cert
+  namespace: provider-system
+data:
+  tls.crt: B64 of file tls.crt
+  tls.key: B64 of file tls.key
+$ kubectl apply -f cert-secrets.yaml
 ```
 
 1. Build and load the docker image

--- a/charts/artifact-attestations-opa-provider/templates/artifact-attestations-opa-provider-deployment.yaml
+++ b/charts/artifact-attestations-opa-provider/templates/artifact-attestations-opa-provider-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         args:
         - -namespace=provider-system
         - -image-pull-secret=aa-ghcr-login-secret
+        - -certs={{ .Values.certDir }}
         ports:
         - containerPort: {{ .Values.port }}
           protocol: TCP
@@ -42,9 +43,22 @@ spec:
           mountPath: /tmp/gatekeeper
           readOnly: true
         {{- end }}
+        volumeMounts:
+        - name: provider-tls-cert
+          mountPath: /certs
+          readOnly: true
       restartPolicy: Always
       nodeSelector:
         kubernetes.io/os: linux
+      volumes:
+      - name: provider-tls-cert
+        secret:
+          secretName: provider-tls-cert
+          items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
       {{- if .Values.clientCAFile }}
       volumes:
       - name: gatekeeper-ca-cert
@@ -54,5 +68,3 @@ spec:
           - key: ca.crt
             path: ca.crt
       {{- end }}
-      imagePullSecrets:
-        - name: aa-ghcr-login-secret

--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	noPGI       = flag.Bool("no-public-good", false, "disable public good sigstore instance")
+	certsDir    = flag.String("certs", "", "Directory to where TLS certs are stored")
 	trustDomain = flag.String("trust-domain", "", "trust domain to use")
 	tufRepo     = flag.String("tuf-repo", "", "URL to TUF repository")
 	tufRoot     = flag.String("tuf-root", "", "Path to a root.json used to initialize TUF repository")
@@ -30,7 +31,6 @@ var (
 const (
 	certName = "tls.crt"
 	keyName  = "tls.key"
-	certsDir = "certs"
 )
 
 type transport struct {
@@ -64,8 +64,8 @@ func main() {
 	}
 
 	http.HandleFunc("/", t.validate)
-	var cf = filepath.Join(certsDir, certName)
-	var kf = filepath.Join(certsDir, keyName)
+	var cf = filepath.Join(*certsDir, certName)
+	var kf = filepath.Join(*certsDir, keyName)
 
 	fmt.Println("starting server...")
 	if err = srv.ListenAndServeTLS(cf, kf); err != nil {


### PR DESCRIPTION
They are now added as secrets to the cluster, and mounted into the container so that any user can provide their own certs.

A follow up change will make the overall experience with helm better so the secret is automatically created during install.