### PR TITLE
Make sure all images pulled are from this repository to avoid external

### DIFF
--- a/.github/workflows/integrationtests.yaml
+++ b/.github/workflows/integrationtests.yaml
@@ -9,12 +9,42 @@ on:
 permissions: {}
 
 jobs:
+  build-test-image:
+    name: Test build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push unsigned image
+        id: push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:unsigned
+
   test:
-    name: Test
+    name: Integration test
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read
+    needs: build-test-image
 
     steps:
       - name: Checkout repository

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -38,7 +38,7 @@ UNSIGNED_BODY=`cat <<EOF
 EOF
 `
 
-SIGNED_IMAGE="ghcr.io/tinaheidinger/test-container:latest"
+SIGNED_IMAGE="ghcr.io/github/artifact-attestations-opa-provider:dev"
 SIGNED_BODY=`cat <<EOF
 {
     "apiVersion": "externaldata.gatekeeper.sh/v1beta1",


### PR DESCRIPTION
dependencies. Also build the unsigned image to make sure it exists.