### PR TITLE
[ACR] Backfill v0.0.5-alpha to ACR

### DIFF
--- a/.github/workflows/release_acr.yaml
+++ b/.github/workflows/release_acr.yaml
@@ -1,0 +1,52 @@
+name: Backfill v0.0.5-alpha to ACR
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - backfill-acr-v0.0.5-alpha
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Build and Release OCI Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to Azure Container Registry (ACR)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ secrets.ACR_MODA_REGISTRY }}
+          username: ${{ secrets.ACR_MODA_USER }}
+          password: ${{ secrets.ACR_MODA_TOKEN }}
+
+      - name: Build and push Docker image to ACR
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.ACR_MODA_REGISTRY }}/artifact-attestations-opa-provider:v0.0.5-alpha
+          platforms: linux/amd64,linux/arm64
+
+      - name: Attest build provenance for ACR
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ secrets.ACR_MODA_REGISTRY }}/artifact-attestations-opa-provider
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
One-shot backfill: builds from the exact v0.0.5-alpha commit (a5791d4) and pushes to ACR with attestation.

This branch/PR can be closed after the workflow completes successfully.

Look at https://github.com/github/artifact-attestations-opa-provider/tags
https://github.com/github/artifact-attestations-opa-provider/releases/tag/v0.0.5-alpha

you can see it was tagged on image https://github.com/github/artifact-attestations-opa-provider/commit/a5791d4f73094b527abe6aa05a568fc50af8ff51

so let's rebuild that and push up to ACR