### PR TITLE
Use GH base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+registries:
+  ghcr:
+    type: docker-registry
+    url: ghcr.io
+    username: PAT
+    password: ${{ secrets.BASE_CONTAINER_IMAGE_READER_DEPENDABOT }}
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
@@ -27,11 +33,6 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 3
-    groups:
-      minor-patch:
-        update-types:
-          - "minor"
-          - "patch"
+      interval: daily
+    registries: [ghcr]
+    labels: [dependencies, docker]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS builder
-
+FROM ghcr.io/github/gh-base-image/go-builder-noble:20260731-110030-ga8facf72f@sha256:54e0e2bd2fcd8a9a0e0d538a79dfcb3168cd713e93406a9c66232baeabf1efe7 AS builder
 WORKDIR /tmp/aaop
 
 # Setup cache
@@ -11,7 +10,8 @@ RUN go mod download
 COPY . .
 RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache go build -o aaop cmd/aaop/aaop.go
 
-FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+
+FROM ghcr.io/github/gh-base-image/gh-base-noble:20260731-094650-g61ba3829f@sha256:965152ebc8311c75bc9db9fc1c178a8c04718ca5d5521c30f55ba40ef229ff4d
 
 WORKDIR /
 RUN mkdir /certs

--- a/Dockerfile.unsigned
+++ b/Dockerfile.unsigned
@@ -1,4 +1,3 @@
-# v3.21.3
-FROM alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+FROM ghcr.io/github/gh-base-image/gh-base-noble:20260731-094650-g61ba3829f@sha256:965152ebc8311c75bc9db9fc1c178a8c04718ca5d5521c30f55ba40ef229ff4d
 
 RUN echo "arbitrary string to avoid collision with signed image" > /dummyfile.txt


### PR DESCRIPTION
https://github.com/github/vuln-mgmt/issues/208295
We (Compute Platform) consume this from https://github.com/github/attestation-provider so we need it to use GH base images.

https://github.com/github/secrets-federation/pull/6064
