### PR TITLE
Classify OCI bundle-fetch failures for better troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,14 @@ The metrics exposed beyond the default Prometheus metrics are:
 
 * `aaop_attestations_retrieved_total`: the total number of
   attestations downloaded from the OCI registry.
-* `aaop_attestations_retrieved_failed`: the total number of
-  failed attestations downloaded from the OCI registry.
+* `aaop_attestations_retrieved_fail`: the total number of
+  failed bundle fetches from the OCI registry. Labeled by `reason`
+  (e.g. `timeout`, `throttled`, `unauthorized`, `forbidden`,
+  `referrers_unavailable`, `descriptor_error`, `blob_error`,
+  `bundle_invalid`, `unknown`).
 * `aaop_attestations_verified_ok`: the total number of verified
   attestations.
-* `aaop_attestations_verified_failed`: the total number of
+* `aaop_attestations_verified_fail`: the total number of
   attestations that failed to verify.
 * `aaop_attestations_request_timer`: the duration in seconds for
   the validation webhook.

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -47,6 +47,70 @@ func (n *NonRecoverableError) Unwrap() error {
 	return n.Err
 }
 
+// FailureKind is a stable, low-cardinality classification of why a bundle
+// fetch failed. It is safe to use as a metric label value and a log field.
+type FailureKind string
+
+const (
+	// KindTimeout indicates an attempt exceeded its timeout / the context
+	// deadline was exceeded.
+	KindTimeout FailureKind = "timeout"
+	// KindCanceled indicates the parent context was canceled.
+	KindCanceled FailureKind = "canceled"
+	// KindUnauthorized indicates the registry returned HTTP 401.
+	KindUnauthorized FailureKind = "unauthorized"
+	// KindForbidden indicates the registry returned HTTP 403 / denied.
+	KindForbidden FailureKind = "forbidden"
+	// KindThrottled indicates the registry returned HTTP 429 (rate limited).
+	KindThrottled FailureKind = "throttled"
+	// KindReferrersUnavailable indicates the OCI Referrers API call failed.
+	KindReferrersUnavailable FailureKind = "referrers_unavailable"
+	// KindDescriptorError indicates the image manifest (descriptor) GET failed.
+	KindDescriptorError FailureKind = "descriptor_error"
+	// KindBlobError indicates fetching a referrer image / blob failed.
+	KindBlobError FailureKind = "blob_error"
+	// KindBundleInvalid indicates a fetched bundle could not be decoded.
+	KindBundleInvalid FailureKind = "bundle_invalid"
+	// KindUnknown is the fallback when the error could not be classified.
+	KindUnknown FailureKind = "unknown"
+)
+
+// Step identifies which stage of the OCI bundle fetch failed.
+type Step string
+
+const (
+	// StepDescriptor is the initial image manifest (descriptor) GET.
+	StepDescriptor Step = "descriptor"
+	// StepReferrers is the OCI Referrers API lookup.
+	StepReferrers Step = "referrers"
+	// StepBlob is fetching a referrer image / reading its layer.
+	StepBlob Step = "blob"
+	// StepDecode is unmarshalling the bundle JSON.
+	StepDecode Step = "decode"
+)
+
+// FetchError is a structured error describing a failed attempt to fetch a
+// bundle from an OCI registry. It records which Step failed, a stable failure
+// Kind, how many attempts were made, and (when known) the HTTP StatusCode, so
+// callers can log, categorize, and emit metrics without parsing error strings.
+type FetchError struct {
+	Step        Step
+	Kind        FailureKind
+	Attempts    int
+	StatusCode  int
+	Recoverable bool
+	Err         error
+}
+
+func (e *FetchError) Error() string {
+	return fmt.Sprintf("error fetching bundle: step=%s reason=%s attempts=%d status=%d: %v",
+		e.Step, e.Kind, e.Attempts, e.StatusCode, e.Err)
+}
+
+func (e *FetchError) Unwrap() error {
+	return e.Err
+}
+
 // DefaultBundleFetcher is the default implementation of the BundleFetcher.
 type DefaultBundleFetcher struct{}
 
@@ -73,6 +137,7 @@ type bundleAttempt func(context.Context) ([]*bundle.Bundle, *v1.Hash, error)
 
 func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Duration, attempt bundleAttempt) ([]*bundle.Bundle, *v1.Hash, error) {
 	var lastErr error
+	var attempts int
 
 	for i := 0; i < maxAttempts; i++ {
 		if i > 0 && delay > 0 {
@@ -80,13 +145,19 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			select {
 			case <-ctx.Done():
 				t.Stop()
-				return nil, nil, fmt.Errorf("error fetching bundle: %w", ctx.Err())
+				return nil, nil, &FetchError{
+					Kind:        kindFromContext(ctx.Err()),
+					Attempts:    attempts,
+					Recoverable: false,
+					Err:         ctx.Err(),
+				}
 			case <-t.C:
 				// we are ready to proceed with next
 				// attempt
 			}
 		}
 
+		attempts = i + 1
 		ictx, cancel := context.WithTimeout(ctx, timeout)
 		b, h, err := attempt(ictx)
 		cancel()
@@ -94,19 +165,29 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			return b, h, nil
 		}
 		lastErr = err
+
+		// Stop early on errors that a retry cannot fix (auth, invalid
+		// bundle). Record how many attempts we made for observability.
+		var fe *FetchError
+		if errors.As(err, &fe) && !fe.Recoverable {
+			fe.Attempts = attempts
+			return nil, nil, fe
+		}
 		var nce *NonRecoverableError
 		if errors.As(err, &nce) {
 			return nil, nil, err
 		}
-		if err := ctx.Err(); err != nil {
-			return nil, nil, fmt.Errorf("error retrieving bundle: %w", err)
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, nil, &FetchError{
+				Kind:        kindFromContext(cerr),
+				Attempts:    attempts,
+				Recoverable: false,
+				Err:         cerr,
+			}
 		}
 	}
 
-	if lastErr == nil {
-		lastErr = errors.New("error (timeout) retrieving bundle")
-	}
-	return nil, nil, lastErr
+	return nil, nil, finalizeFetchError(lastErr, attempts)
 }
 
 // DoBundleFromName fetches a sigstore bundle for a container from
@@ -119,20 +200,17 @@ func DoBundleFromName(ctx context.Context, ref name.Reference, ro []remote.Optio
 
 	desc, err := remote.Get(ref, opts...)
 	if err != nil {
-		if isAuthenticationError(err) {
-			return nil, nil, &NonRecoverableError{Op: "getting image descriptor", Err: err}
-		}
-		return nil, nil, fmt.Errorf("error getting image descriptor: %w", err)
+		return nil, nil, newFetchError(StepDescriptor, KindDescriptorError, err)
 	}
 
 	digest := ref.Context().Digest(desc.Digest.String())
 	referrers, err := remote.Referrers(digest, opts...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting referrers: %w", err)
+		return nil, nil, newFetchError(StepReferrers, KindReferrersUnavailable, err)
 	}
 	refManifest, err := referrers.IndexManifest()
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting referrers manifest: %w", err)
+		return nil, nil, newFetchError(StepReferrers, KindReferrersUnavailable, err)
 	}
 
 	bundles := make([]*bundle.Bundle, 0)
@@ -144,29 +222,30 @@ func DoBundleFromName(ctx context.Context, ref name.Reference, ro []remote.Optio
 
 		refImg, err := remote.Image(ref.Context().Digest(refDesc.Digest.String()), opts...)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error getting referrer image: %w", err)
+			return nil, nil, newFetchError(StepBlob, KindBlobError, err)
 		}
 		layers, err := refImg.Layers()
 		if err != nil {
-			return nil, nil, fmt.Errorf("error getting referrer image: %w", err)
+			return nil, nil, newFetchError(StepBlob, KindBlobError, err)
 		}
 		layer0, err := layers[0].Uncompressed()
 		if err != nil {
-			return nil, nil, fmt.Errorf("error getting referrer image: %w", err)
+			return nil, nil, newFetchError(StepBlob, KindBlobError, err)
 		}
 		bundleBytes, err := io.ReadAll(layer0)
 		layer0.Close()
 		if err != nil {
-			return nil, nil, fmt.Errorf("error getting referrer image: %w", err)
+			return nil, nil, newFetchError(StepBlob, KindBlobError, err)
 		}
 		b := &bundle.Bundle{}
 		err = b.UnmarshalJSON(bundleBytes)
 		if err != nil {
-			return nil, nil,
-				&NonRecoverableError{
-					"unmarshalling bundle JSON",
-					err,
-				}
+			return nil, nil, &FetchError{
+				Step:        StepDecode,
+				Kind:        KindBundleInvalid,
+				Recoverable: false,
+				Err:         err,
+			}
 		}
 		bundles = append(bundles, b)
 	}
@@ -195,6 +274,116 @@ func isAuthenticationError(err error) bool {
 	}
 
 	return false
+}
+
+// newFetchError builds a FetchError for a failed fetch step. It derives the
+// failure Kind (and HTTP status, when available) from the underlying error,
+// falling back to the supplied kind for unclassified errors. Authentication
+// failures and invalid bundles are marked non-recoverable so retries stop.
+func newFetchError(step Step, fallback FailureKind, err error) *FetchError {
+	kind, code := classifyTransport(err)
+	if kind == KindUnknown {
+		kind = fallback
+	}
+	recoverable := kind != KindUnauthorized &&
+		kind != KindForbidden &&
+		kind != KindBundleInvalid
+	return &FetchError{
+		Step:        step,
+		Kind:        kind,
+		StatusCode:  code,
+		Recoverable: recoverable,
+		Err:         err,
+	}
+}
+
+// classifyTransport maps an error to a stable FailureKind and, when the error
+// is an OCI transport error, the HTTP status code.
+func classifyTransport(err error) (FailureKind, int) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return KindTimeout, 0
+	}
+	if errors.Is(err, context.Canceled) {
+		return KindCanceled, 0
+	}
+
+	var transportErr *transport.Error
+	if errors.As(err, &transportErr) {
+		switch transportErr.StatusCode {
+		case http.StatusUnauthorized:
+			return KindUnauthorized, transportErr.StatusCode
+		case http.StatusForbidden:
+			return KindForbidden, transportErr.StatusCode
+		case http.StatusTooManyRequests:
+			return KindThrottled, transportErr.StatusCode
+		}
+		for _, diagnostic := range transportErr.Errors {
+			if diagnostic.Code == transport.UnauthorizedErrorCode {
+				return KindUnauthorized, transportErr.StatusCode
+			}
+			if diagnostic.Code == transport.DeniedErrorCode {
+				return KindForbidden, transportErr.StatusCode
+			}
+			if diagnostic.Code == transport.TooManyRequestsErrorCode {
+				return KindThrottled, transportErr.StatusCode
+			}
+		}
+		return KindUnknown, transportErr.StatusCode
+	}
+
+	return KindUnknown, 0
+}
+
+// kindFromContext classifies a context error.
+func kindFromContext(err error) FailureKind {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return KindTimeout
+	case errors.Is(err, context.Canceled):
+		return KindCanceled
+	default:
+		return KindUnknown
+	}
+}
+
+// finalizeFetchError normalizes the error returned after all attempts are
+// exhausted into a FetchError carrying the total number of attempts.
+func finalizeFetchError(err error, attempts int) error {
+	if err == nil {
+		return &FetchError{
+			Kind:     KindTimeout,
+			Attempts: attempts,
+			Err:      errors.New("no bundle fetch attempts were made"),
+		}
+	}
+	var fe *FetchError
+	if errors.As(err, &fe) {
+		fe.Attempts = attempts
+		return fe
+	}
+	kind, code := classifyTransport(err)
+	return &FetchError{
+		Kind:        kind,
+		StatusCode:  code,
+		Attempts:    attempts,
+		Recoverable: true,
+		Err:         err,
+	}
+}
+
+// Classify extracts a stable, low-cardinality failure reason, the fetch step,
+// and the number of attempts from a bundle fetch error. It is safe to call
+// with any error; unrecognized errors are reported with reason "unknown".
+func Classify(err error) (reason string, step string, attempts int) {
+	var fe *FetchError
+	if errors.As(err, &fe) {
+		reason = string(fe.Kind)
+		if reason == "" {
+			reason = string(KindUnknown)
+		}
+		return reason, string(fe.Step), fe.Attempts
+	}
+	return string(KindUnknown), "", 0
 }
 
 // GetRemoteOptions returns the options to provide when accessing remote

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -200,17 +200,17 @@ func DoBundleFromName(ctx context.Context, ref name.Reference, ro []remote.Optio
 
 	desc, err := remote.Get(ref, opts...)
 	if err != nil {
-		return nil, nil, newFetchError(StepDescriptor, KindDescriptorError, err)
+		return nil, nil, newDescriptorError(err)
 	}
 
 	digest := ref.Context().Digest(desc.Digest.String())
 	referrers, err := remote.Referrers(digest, opts...)
 	if err != nil {
-		return nil, nil, newFetchError(StepReferrers, KindReferrersUnavailable, err)
+		return nil, nil, newReferrersError(err)
 	}
 	refManifest, err := referrers.IndexManifest()
 	if err != nil {
-		return nil, nil, newFetchError(StepReferrers, KindReferrersUnavailable, err)
+		return nil, nil, newReferrersError(err)
 	}
 
 	bundles := make([]*bundle.Bundle, 0)
@@ -222,20 +222,20 @@ func DoBundleFromName(ctx context.Context, ref name.Reference, ro []remote.Optio
 
 		refImg, err := remote.Image(ref.Context().Digest(refDesc.Digest.String()), opts...)
 		if err != nil {
-			return nil, nil, newFetchError(StepBlob, KindBlobError, err)
+			return nil, nil, newBlobError(err)
 		}
 		layers, err := refImg.Layers()
 		if err != nil {
-			return nil, nil, newFetchError(StepBlob, KindBlobError, err)
+			return nil, nil, newBlobError(err)
 		}
 		layer0, err := layers[0].Uncompressed()
 		if err != nil {
-			return nil, nil, newFetchError(StepBlob, KindBlobError, err)
+			return nil, nil, newBlobError(err)
 		}
 		bundleBytes, err := io.ReadAll(layer0)
 		layer0.Close()
 		if err != nil {
-			return nil, nil, newFetchError(StepBlob, KindBlobError, err)
+			return nil, nil, newBlobError(err)
 		}
 		b := &bundle.Bundle{}
 		err = b.UnmarshalJSON(bundleBytes)
@@ -297,6 +297,21 @@ func newFetchError(step Step, fallback FailureKind, err error) *FetchError {
 	}
 }
 
+// newDescriptorError builds a FetchError for a failed image manifest GET.
+func newDescriptorError(err error) *FetchError {
+	return newFetchError(StepDescriptor, KindDescriptorError, err)
+}
+
+// newReferrersError builds a FetchError for a failed OCI Referrers API call.
+func newReferrersError(err error) *FetchError {
+	return newFetchError(StepReferrers, KindReferrersUnavailable, err)
+}
+
+// newBlobError builds a FetchError for a failed referrer image / blob fetch.
+func newBlobError(err error) *FetchError {
+	return newFetchError(StepBlob, KindBlobError, err)
+}
+
 // classifyTransport maps an error to a stable FailureKind and, when the error
 // is an OCI transport error, the HTTP status code.
 func classifyTransport(err error) (FailureKind, int) {
@@ -350,9 +365,11 @@ func kindFromContext(err error) FailureKind {
 // exhausted into a FetchError carrying the total number of attempts.
 func finalizeFetchError(err error, attempts int) error {
 	if err == nil {
+		// Defensive: this is only reached when the retry loop ran zero
+		// iterations (maxAttempts < 1), so no attempt was ever made.
 		return &FetchError{
-			Kind:     KindTimeout,
-			Attempts: attempts,
+			Kind:     KindUnknown,
+			Attempts: 0,
 			Err:      errors.New("no bundle fetch attempts were made"),
 		}
 	}

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -178,7 +178,14 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			return nil, nil, err
 		}
 		if cerr := ctx.Err(); cerr != nil {
+			// Preserve the step from the in-flight attempt (if any) so
+			// cancellation failures still report where they occurred.
+			var step Step
+			if fe != nil {
+				step = fe.Step
+			}
 			return nil, nil, &FetchError{
+				Step:        step,
 				Kind:        kindFromContext(cerr),
 				Attempts:    attempts,
 				Recoverable: false,
@@ -255,25 +262,6 @@ func DoBundleFromName(ctx context.Context, ref name.Reference, ro []remote.Optio
 	}
 
 	return bundles, &desc.Digest, nil
-}
-
-func isAuthenticationError(err error) bool {
-	var transportErr *transport.Error
-	if !errors.As(err, &transportErr) {
-		return false
-	}
-
-	if transportErr.StatusCode == http.StatusUnauthorized || transportErr.StatusCode == http.StatusForbidden {
-		return true
-	}
-
-	for _, diagnostic := range transportErr.Errors {
-		if diagnostic.Code == transport.UnauthorizedErrorCode || diagnostic.Code == transport.DeniedErrorCode {
-			return true
-		}
-	}
-
-	return false
 }
 
 // newFetchError builds a FetchError for a failed fetch step. It derives the

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"runtime"
 	"strings"
@@ -31,21 +32,6 @@ var (
 	// Delay between attempts to fetch bundles.
 	Delay = time.Duration(0)
 )
-
-// NonRecoverableError represent a bundle fetching error that can't
-// be recovered from.
-type NonRecoverableError struct {
-	Op  string
-	Err error
-}
-
-func (n *NonRecoverableError) Error() string {
-	return fmt.Sprintf("non recoverable error: %s: %v", n.Op, n.Err)
-}
-
-func (n *NonRecoverableError) Unwrap() error {
-	return n.Err
-}
 
 // FailureKind is a stable, low-cardinality classification of why a bundle
 // fetch failed. It is safe to use as a metric label value and a log field.
@@ -173,10 +159,6 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			fe.Attempts = attempts
 			return nil, nil, fe
 		}
-		var nce *NonRecoverableError
-		if errors.As(err, &nce) {
-			return nil, nil, err
-		}
 		if cerr := ctx.Err(); cerr != nil {
 			// Preserve the step from the in-flight attempt (if any) so
 			// cancellation failures still report where they occurred.
@@ -192,6 +174,16 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 				Err:         cerr,
 			}
 		}
+
+		// Log each retryable attempt failure at debug level so an operator
+		// can dig into the individual failures behind a retried fetch.
+		reason, step, _ := Classify(err)
+		slog.Debug("bundle fetch attempt failed",
+			"attempt", attempts,
+			"max_attempts", maxAttempts,
+			"reason", reason,
+			"step", step,
+			"error", err)
 	}
 
 	return nil, nil, finalizeFetchError(lastErr, attempts)

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -180,6 +180,21 @@ func TestNewFetchErrorClassifiesAuthAsNonRecoverable(t *testing.T) {
 	assert.True(t, fe.Recoverable)
 }
 
+func TestNewFetchErrorClassifiesThrottling(t *testing.T) {
+	// HTTP 429 status-code branch.
+	fe := newFetchError(StepReferrers, KindReferrersUnavailable, &transport.Error{StatusCode: http.StatusTooManyRequests})
+	assert.Equal(t, KindThrottled, fe.Kind)
+	assert.Equal(t, http.StatusTooManyRequests, fe.StatusCode)
+	assert.True(t, fe.Recoverable, "throttling should be retried")
+
+	// TooManyRequests diagnostic-code branch (status code not populated).
+	fe = newFetchError(StepDescriptor, KindDescriptorError, &transport.Error{
+		Errors: []transport.Diagnostic{{Code: transport.TooManyRequestsErrorCode}},
+	})
+	assert.Equal(t, KindThrottled, fe.Kind)
+	assert.True(t, fe.Recoverable, "throttling should be retried")
+}
+
 func TestRetryBundleTimeoutSetsAttemptsAndReason(t *testing.T) {
 	const maxAttempts = 3
 

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -92,54 +92,86 @@ func TestRetryBundleReturnsLastError(t *testing.T) {
 	assert.NotErrorIs(t, err, firstErr)
 }
 
-func TestIsAuthenticationError(t *testing.T) {
+func TestClassifyTransport(t *testing.T) {
 	tests := []struct {
-		name string
-		err  error
-		want bool
+		name     string
+		err      error
+		wantKind FailureKind
+		wantCode int
 	}{
 		{
-			name: "unauthorized status",
-			err:  &transport.Error{StatusCode: http.StatusUnauthorized},
-			want: true,
+			name:     "unauthorized status",
+			err:      &transport.Error{StatusCode: http.StatusUnauthorized},
+			wantKind: KindUnauthorized,
+			wantCode: http.StatusUnauthorized,
 		},
 		{
-			name: "forbidden status",
-			err:  &transport.Error{StatusCode: http.StatusForbidden},
-			want: true,
+			name:     "forbidden status",
+			err:      &transport.Error{StatusCode: http.StatusForbidden},
+			wantKind: KindForbidden,
+			wantCode: http.StatusForbidden,
+		},
+		{
+			name:     "too many requests status",
+			err:      &transport.Error{StatusCode: http.StatusTooManyRequests},
+			wantKind: KindThrottled,
+			wantCode: http.StatusTooManyRequests,
 		},
 		{
 			name: "unauthorized diagnostic",
 			err: &transport.Error{Errors: []transport.Diagnostic{
 				{Code: transport.UnauthorizedErrorCode},
 			}},
-			want: true,
+			wantKind: KindUnauthorized,
 		},
 		{
 			name: "denied diagnostic",
 			err: &transport.Error{Errors: []transport.Diagnostic{
 				{Code: transport.DeniedErrorCode},
 			}},
-			want: true,
+			wantKind: KindForbidden,
 		},
 		{
-			name: "wrapped authentication error",
-			err:  fmt.Errorf("remote get: %w", &transport.Error{StatusCode: http.StatusUnauthorized}),
-			want: true,
+			name: "too many requests diagnostic",
+			err: &transport.Error{Errors: []transport.Diagnostic{
+				{Code: transport.TooManyRequestsErrorCode},
+			}},
+			wantKind: KindThrottled,
 		},
 		{
-			name: "server error",
-			err:  &transport.Error{StatusCode: http.StatusInternalServerError},
+			name:     "wrapped authentication error",
+			err:      fmt.Errorf("remote get: %w", &transport.Error{StatusCode: http.StatusUnauthorized}),
+			wantKind: KindUnauthorized,
+			wantCode: http.StatusUnauthorized,
 		},
 		{
-			name: "ordinary error",
-			err:  errors.New("connection reset"),
+			name:     "server error is not auth",
+			err:      &transport.Error{StatusCode: http.StatusInternalServerError},
+			wantKind: KindUnknown,
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:     "deadline exceeded",
+			err:      context.DeadlineExceeded,
+			wantKind: KindTimeout,
+		},
+		{
+			name:     "context canceled",
+			err:      context.Canceled,
+			wantKind: KindCanceled,
+		},
+		{
+			name:     "ordinary error",
+			err:      errors.New("connection reset"),
+			wantKind: KindUnknown,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, isAuthenticationError(test.err))
+			kind, code := classifyTransport(test.err)
+			assert.Equal(t, test.wantKind, kind)
+			assert.Equal(t, test.wantCode, code)
 		})
 	}
 }
@@ -193,6 +225,20 @@ func TestNewFetchErrorClassifiesThrottling(t *testing.T) {
 	})
 	assert.Equal(t, KindThrottled, fe.Kind)
 	assert.True(t, fe.Recoverable, "throttling should be retried")
+}
+
+func TestRetryBundlePreservesStepOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	_, _, err := retryBundle(ctx, 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		cancel()
+		return nil, nil, newReferrersError(errors.New("boom"))
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindCanceled, fe.Kind)
+	assert.Equal(t, StepReferrers, fe.Step, "cancellation error should preserve the in-flight step")
 }
 
 func TestRetryBundleTimeoutSetsAttemptsAndReason(t *testing.T) {

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -48,19 +48,6 @@ func TestRetryBundleReturnsSuccessfulAttempt(t *testing.T) {
 	assert.Same(t, expectedHash, hash)
 }
 
-func TestRetryBundleStopsOnNonRecoverableError(t *testing.T) {
-	expectedErr := &NonRecoverableError{Op: "decode", Err: errors.New("invalid bundle")}
-	var attempts int
-
-	_, _, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
-		attempts++
-		return nil, nil, expectedErr
-	})
-
-	require.ErrorIs(t, err, expectedErr)
-	assert.Equal(t, 1, attempts)
-}
-
 func TestRetryBundleStopsWhenParentIsCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	var attempts int

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -143,3 +143,68 @@ func TestIsAuthenticationError(t *testing.T) {
 		})
 	}
 }
+
+func TestClassify(t *testing.T) {
+	fe := &FetchError{Step: StepReferrers, Kind: KindReferrersUnavailable, Attempts: 3}
+	reason, step, attempts := Classify(fe)
+	assert.Equal(t, "referrers_unavailable", reason)
+	assert.Equal(t, "referrers", step)
+	assert.Equal(t, 3, attempts)
+
+	reason, step, attempts = Classify(errors.New("some other error"))
+	assert.Equal(t, "unknown", reason)
+	assert.Empty(t, step)
+	assert.Equal(t, 0, attempts)
+
+	reason, _, _ = Classify(fmt.Errorf("wrapped: %w", &FetchError{Kind: KindTimeout}))
+	assert.Equal(t, "timeout", reason)
+}
+
+func TestFetchErrorErrorAndUnwrap(t *testing.T) {
+	inner := errors.New("boom")
+	fe := &FetchError{Step: StepBlob, Kind: KindBlobError, Attempts: 2, StatusCode: 500, Err: inner}
+
+	assert.Contains(t, fe.Error(), "step=blob")
+	assert.Contains(t, fe.Error(), "reason=blob_error")
+	assert.ErrorIs(t, fe, inner)
+}
+
+func TestNewFetchErrorClassifiesAuthAsNonRecoverable(t *testing.T) {
+	fe := newFetchError(StepDescriptor, KindDescriptorError, &transport.Error{StatusCode: http.StatusForbidden})
+	assert.Equal(t, KindForbidden, fe.Kind)
+	assert.False(t, fe.Recoverable)
+	assert.Equal(t, http.StatusForbidden, fe.StatusCode)
+
+	fe = newFetchError(StepBlob, KindBlobError, errors.New("connection reset"))
+	assert.Equal(t, KindBlobError, fe.Kind)
+	assert.True(t, fe.Recoverable)
+}
+
+func TestRetryBundleTimeoutSetsAttemptsAndReason(t *testing.T) {
+	const maxAttempts = 3
+
+	_, _, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		<-ctx.Done()
+		return nil, nil, newFetchError(StepDescriptor, KindDescriptorError, ctx.Err())
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindTimeout, fe.Kind)
+	assert.Equal(t, maxAttempts, fe.Attempts)
+}
+
+func TestRetryBundleStopsOnNonRecoverableFetchError(t *testing.T) {
+	var attempts int
+
+	_, _, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		attempts++
+		return nil, nil, &FetchError{Step: StepDescriptor, Kind: KindUnauthorized, Recoverable: false, Err: errors.New("401")}
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindUnauthorized, fe.Kind)
+	assert.Equal(t, 1, attempts)
+	assert.Equal(t, 1, fe.Attempts)
+}

--- a/pkg/metrics/prom.go
+++ b/pkg/metrics/prom.go
@@ -13,10 +13,10 @@ var (
 	})
 
 	//nolint: revive
-	AttestationsRetrieveFail = promauto.NewCounter(prometheus.CounterOpts{
+	AttestationsRetrieveFail = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "aaop_attestations_retrieved_fail",
 		Help: "The total number of attestations retrieve failure",
-	})
+	}, []string{"reason"})
 
 	//nolint: revive
 	AttestationsMissing = promauto.NewCounter(prometheus.CounterOpts{

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 
+	"github.com/github/artifact-attestations-opa-provider/pkg/fetcher"
 	"github.com/github/artifact-attestations-opa-provider/pkg/metrics"
 )
 
@@ -109,23 +110,34 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		start := time.Now()
 		bundles, hash, err := p.bf.BundleFromName(ctx, ref, ro)
 		dur := time.Since(start)
-		metrics.AttestationsRetrieved.Add(float64(len(bundles)))
+		// Record the fetch latency for both successful and failed fetches.
+		// The tail of this histogram (failed fetches timing out) is a key
+		// signal when troubleshooting registry latency, so it must include
+		// failures.
 		metrics.AttestationsPullTimer.Observe(dur.Seconds())
-		slog.Info("validate: fetched OCI bundles",
-			"count", len(bundles),
-			"duration", dur.Seconds())
 
 		if err != nil {
-			metrics.AttestationsRetrieveFail.Inc()
+			reason, step, attempts := fetcher.Classify(err)
+			metrics.AttestationsRetrieveFail.WithLabelValues(reason).Inc()
 			slog.Error("validate: error fetching bundles",
 				"image", key,
+				"reason", reason,
+				"step", step,
+				"attempts", attempts,
+				"duration_s", dur.Seconds(),
 				"error", err)
 			results = append(results, externaldata.Item{
 				Key:   key,
-				Error: "error_fetching_bundle",
+				Error: "error_fetching_bundle_" + reason,
 			})
 			continue
 		}
+
+		metrics.AttestationsRetrieved.Add(float64(len(bundles)))
+		slog.Info("validate: fetched OCI bundles",
+			"image", key,
+			"count", len(bundles),
+			"duration_s", dur.Seconds())
 
 		if len(bundles) == 0 {
 			metrics.AttestationsMissing.Inc()

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -217,7 +217,7 @@ func TestInvalid(t *testing.T) {
 		},
 		{
 			image: brokenImageName,
-			error: "error_fetching_bundle",
+			error: "error_fetching_bundle_unknown",
 		},
 	}
 

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -5,7 +5,12 @@ set -u
 set -o pipefail
 
 metrics_failed() {
-    curl -s http://localhost:9090/metrics | grep ^aaop_attestations_retrieved_fail | sed 's/aaop_attestations_retrieved_fail //g' | tr -d '\n'
+    # aaop_attestations_retrieved_fail is a labeled counter
+    # (aaop_attestations_retrieved_fail{reason="..."} N), so sum the value
+    # (last field) across all reason series and print the integer total.
+    # Filtering in awk avoids grep exiting non-zero (pipefail) when no
+    # failures have been recorded yet.
+    curl -s http://localhost:9090/metrics | awk '/^aaop_attestations_retrieved_fail\{/ {sum += $NF} END {printf "%d", sum}'
 }
 
 metrics_no_attestation() {


### PR DESCRIPTION
## Why

Intermittent failures fetching attestation bundles from ACR (`dxcrprod.azurecr.io`) are blocking the move to enforce/blocking mode, and our logging makes them hard to diagnose:

- Every fetch failure collapses to the opaque per-item error `error_fetching_bundle`, so the Gatekeeper admission log's `errors` array doesn't say **what** failed or **why**.
- The provider's own error log lacks the fields that discriminate root cause — notably the **duration** of the failed fetch (≈9s ⇒ retries timed out → latency; <1s ⇒ auth/non-recoverable) and **which step** failed (manifest GET vs OCI Referrers API vs blob pull).
- The `aaop_attestations_retrieved_fail` metric has no dimension, so failures can't be broken down (timeout vs throttling vs auth) in Datadog.

## What

**Typed, classified fetch errors** (`pkg/fetcher`)
- New `FetchError{Step, Kind, Attempts, StatusCode, Recoverable, Err}` plus a `Classify(err)` helper, replacing brittle `fmt.Errorf`-wrapped strings.
- `Kind` (stable, low-cardinality): `timeout`, `throttled` (HTTP 429), `unauthorized`, `forbidden`, `referrers_unavailable`, `descriptor_error`, `blob_error`, `bundle_invalid`, `unknown`.
- `Step`: `descriptor`, `referrers`, `blob`, `decode`. `Attempts` records how many retries were made; auth/invalid-bundle stay non-recoverable so retries still short-circuit.

**Clearer provider logging & item errors** (`pkg/provider`)
- Failure log now includes `reason`, `step`, `attempts`, and `duration_s`.
- Only logs the `validate: fetched OCI bundles` success line on success (previously emitted with `count=0` on failure — a source of confusion in #7009).
- Pull-latency histogram is still observed on **both** success and failure, so the timeout tail stays visible.
- Returns a specific per-item error `error_fetching_bundle_<reason>` to Gatekeeper. The `error_fetching_bundle` prefix is preserved so existing Splunk/Gatekeeper queries keep matching, while the admission log's `errors` array becomes self-describing.

**Metric breakdown** (`pkg/metrics`)
- Adds a bounded `reason` label to `aaop_attestations_retrieved_fail` so failures can be sliced in Datadog (directly enables the latency-vs-throttle-vs-auth split we couldn't do before).

**Docs**
- Fixes README metric names (`_retrieved_fail` / `_verified_fail`) to match what's actually exported, and documents the new `reason` label.


## Testing

- `go test ./... -race` ✅
- `golangci-lint run ./...` ✅ (0 issues)
- New unit tests for `Classify`, `FetchError` formatting/unwrap, auth-as-non-recoverable, throttle classification, and retry attempt/reason accounting.

## Backward compatibility

- Per-item error strings gain a `_<reason>` suffix but retain the `error_fetching_bundle` substring, so existing queries filtering on it still match.
- The `aaop_attestations_retrieved_fail` metric name is unchanged; it gains a `reason` label.