### PR TITLE
Add short-TTL bundle cache with singleflight de-duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,12 @@ The provider fronts the OCI fetch with two complementary mechanisms:
   concurrent fetches for the same reference collapses into a single upstream
   request whose result is shared with every waiter. This is safe for any
   reference — including mutable tags — because every waiter receives a result
-  computed *now*, so there is no stale-serve window.
+  computed *now*, so there is no stale-serve window. For a tag, joiners share
+  the leader's tag→digest resolution within the (single-fetch) in-flight window;
+  that window is subsumed by the inherent, much larger admission→kubelet-pull
+  TOCTOU present for any mutable-tag admission, so it does not change the
+  security posture — use digest references (or registry-enforced tag
+  immutability) for a strong image binding.
 * **A short-TTL time cache, keyed on the resolved digest.** Repeat validations
   of the same digest are served from memory within the TTL. The time cache is
   **digest-only**: OCI tags are mutable, so a tag can be repointed to a new
@@ -304,9 +309,10 @@ caller's admission request was already cancelled at the webhook deadline. Failed
 fetches are never cached.
 
 The TTL is configured with `-bundle-cache-ttl` (default `60s`; set to `0` to
-disable caching entirely). The cache size is bounded by
-`-bundle-cache-max-entries` (default `4096`; set to `0` for unbounded); when the
-cache is full, storing a new digest evicts the soonest-to-expire entry.
+disable the **time cache** — singleflight de-duplication still runs). The cache
+size is bounded by `-bundle-cache-max-entries` (default `4096`; set to `0` for
+unbounded); when the cache is full, storing a new digest evicts the
+soonest-to-expire entry. Both flags reject negative values at startup.
 
 Each request is also logged with a `request_id`, `image_count`, and, for
 per-image log lines, an `image_index` (1-based position within the

--- a/README.md
+++ b/README.md
@@ -264,9 +264,10 @@ The metrics exposed beyond the default Prometheus metrics are:
 * `aaop_attestations_verification_timer`: the duration in seconds for
   the time it takes to verify the retrieved attestations.
 * `aaop_bundle_cache_hits_total` / `aaop_bundle_cache_misses_total`: the
-  number of digest-keyed bundle fetches served (or not) from the in-memory
-  time cache. Only digest references consult the time cache (see below), so
-  these count digest lookups only.
+  number of digest-keyed bundle lookups served (hit) or not (miss) from the
+  in-memory time cache. Only digest references consult the time cache (see
+  below), so these count digest lookups only; an errored upstream fetch counts
+  as a miss.
 * `aaop_bundle_fetch_deduped_total`: the number of concurrent bundle fetches
   collapsed into a single upstream request by singleflight.
 * `aaop_bundle_cache_entries`: the current number of entries in the cache.
@@ -285,8 +286,8 @@ The provider fronts the OCI fetch with two complementary mechanisms:
 * **Singleflight de-duplication**, keyed on the requested reference. A burst of
   concurrent fetches for the same reference collapses into a single upstream
   request whose result is shared with every waiter. This is safe for any
-  reference — including mutable tags — because every waiter receives a result
-  computed *now*, so there is no stale-serve window. For a tag, joiners share
+  reference — including mutable tags — because it is concurrent-only coalescing,
+  not a persisted cache. For a tag, joiners share
   the leader's tag→digest resolution within the (single-fetch) in-flight window;
   that window is subsumed by the inherent, much larger admission→kubelet-pull
   TOCTOU present for any mutable-tag admission, so it does not change the

--- a/README.md
+++ b/README.md
@@ -297,16 +297,29 @@ The provider fronts the OCI fetch with two complementary mechanisms:
   **digest-only**: OCI tags are mutable, so a tag can be repointed to a new
   digest within the TTL window. Serving a tag from a persisted entry could
   therefore return a verification result for a digest the tag no longer points
-  to — an admission bypass. Digest references are content-addressed and cannot
-  move, so they are always safe to cache. Tag references are still
-  de-duplicated by singleflight; they are simply never read from or written to
-  the time cache. (On a successful tag fetch the resolved digest is warmed into
-  the cache, so a later request that arrives *by digest* can be served.)
+  to — an admission bypass. Digest references are content-addressed, so
+  digest-keying guarantees a moved tag can never substitute a *different image*.
+  Tag references are still de-duplicated by singleflight; they are simply never
+  read from or written to the time cache. (On a successful tag fetch the
+  resolved digest is warmed into the cache, so a later request that arrives *by
+  digest* can be served.)
 
-The de-duplicated fetch runs on a context detached from the triggering caller
-(`context.WithoutCancel`), so it completes and warms the cache even if that
-caller's admission request was already cancelled at the webhook deadline. Failed
-fetches are never cached.
+  This bounds image *identity*, not the attestation set. The referrers for a
+  digest are mutable, so a cached positive result can be up to one TTL stale
+  with respect to attestations being **added or removed** for that digest — in
+  particular, if attestation removal is used as revocation, it is not reflected
+  until the entry expires. Re-verification on a cache hit re-checks the cached
+  material against the current trust root, but does **not** re-fetch the
+  referrer set. Results with **no attestations are not cached**, so a
+  newly-published attestation is picked up on the next validation.
+
+A fetch that has already begun runs on a context detached from the triggering
+caller (`context.WithoutCancel`), so it completes and warms the cache even if
+that caller's admission request is cancelled mid-flight at the webhook deadline.
+A request that is *already* cancelled on arrival does not start a new fetch (it
+only serves an existing cache hit), so a timed-out multi-image validation cannot
+spawn orphaned registry work during a herd. Failed fetches, and results with no
+attestations, are never cached.
 
 The TTL is configured with `-bundle-cache-ttl` (default `60s`; set to `0` to
 disable the **time cache** — singleflight de-duplication still runs). The cache

--- a/README.md
+++ b/README.md
@@ -263,6 +263,25 @@ The metrics exposed beyond the default Prometheus metrics are:
    time it takes to download the attestations from the OCI registry.
 * `aaop_attestations_verification_timer`: the duration in seconds for
   the time it takes to verify the retrieved attestations.
+* `aaop_bundle_cache_hits_total` / `aaop_bundle_cache_misses_total`: the
+  number of bundle fetches served (or not) from the in-memory cache.
+* `aaop_bundle_fetch_deduped_total`: the number of concurrent bundle fetches
+  collapsed into a single upstream request by singleflight.
+* `aaop_bundle_cache_entries`: the current number of entries in the cache.
+
+## Bundle cache
+
+A burst of admission requests for the same image — for example a workload
+rolling out across many clusters at once — produces many concurrent validations
+for the same reference. Each one would otherwise make its own OCI round-trip,
+and that concurrent load is what pushes fetches past the admission timeout.
+
+The provider fronts the OCI fetch with a short-TTL in-memory cache and
+[singleflight](https://pkg.go.dev/golang.org/x/sync/singleflight)
+de-duplication, so repeat validations of a stable digest are served from memory
+and a burst of concurrent identical fetches collapses into a single upstream
+request. The TTL is configured with `-bundle-cache-ttl` (default `60s`; set to
+`0` to disable). Failed fetches are not cached.
 
 Each request is also logged with a `request_id`, `image_count`, and, for
 per-image log lines, an `image_index` (1-based position within the

--- a/README.md
+++ b/README.md
@@ -264,10 +264,14 @@ The metrics exposed beyond the default Prometheus metrics are:
 * `aaop_attestations_verification_timer`: the duration in seconds for
   the time it takes to verify the retrieved attestations.
 * `aaop_bundle_cache_hits_total` / `aaop_bundle_cache_misses_total`: the
-  number of bundle fetches served (or not) from the in-memory cache.
+  number of digest-keyed bundle fetches served (or not) from the in-memory
+  time cache. Only digest references consult the time cache (see below), so
+  these count digest lookups only.
 * `aaop_bundle_fetch_deduped_total`: the number of concurrent bundle fetches
   collapsed into a single upstream request by singleflight.
 * `aaop_bundle_cache_entries`: the current number of entries in the cache.
+* `aaop_bundle_cache_evictions_total`: the number of cache entries evicted
+  because the cache reached its `-bundle-cache-max-entries` size cap.
 
 ## Bundle cache
 
@@ -276,12 +280,33 @@ rolling out across many clusters at once — produces many concurrent validation
 for the same reference. Each one would otherwise make its own OCI round-trip,
 and that concurrent load is what pushes fetches past the admission timeout.
 
-The provider fronts the OCI fetch with a short-TTL in-memory cache and
-[singleflight](https://pkg.go.dev/golang.org/x/sync/singleflight)
-de-duplication, so repeat validations of a stable digest are served from memory
-and a burst of concurrent identical fetches collapses into a single upstream
-request. The TTL is configured with `-bundle-cache-ttl` (default `60s`; set to
-`0` to disable). Failed fetches are not cached.
+The provider fronts the OCI fetch with two complementary mechanisms:
+
+* **Singleflight de-duplication**, keyed on the requested reference. A burst of
+  concurrent fetches for the same reference collapses into a single upstream
+  request whose result is shared with every waiter. This is safe for any
+  reference — including mutable tags — because every waiter receives a result
+  computed *now*, so there is no stale-serve window.
+* **A short-TTL time cache, keyed on the resolved digest.** Repeat validations
+  of the same digest are served from memory within the TTL. The time cache is
+  **digest-only**: OCI tags are mutable, so a tag can be repointed to a new
+  digest within the TTL window. Serving a tag from a persisted entry could
+  therefore return a verification result for a digest the tag no longer points
+  to — an admission bypass. Digest references are content-addressed and cannot
+  move, so they are always safe to cache. Tag references are still
+  de-duplicated by singleflight; they are simply never read from or written to
+  the time cache. (On a successful tag fetch the resolved digest is warmed into
+  the cache, so a later request that arrives *by digest* can be served.)
+
+The de-duplicated fetch runs on a context detached from the triggering caller
+(`context.WithoutCancel`), so it completes and warms the cache even if that
+caller's admission request was already cancelled at the webhook deadline. Failed
+fetches are never cached.
+
+The TTL is configured with `-bundle-cache-ttl` (default `60s`; set to `0` to
+disable caching entirely). The cache size is bounded by
+`-bundle-cache-max-entries` (default `4096`; set to `0` for unbounded); when the
+cache is full, storing a new digest evicts the soonest-to-expire entry.
 
 Each request is also logged with a `request_id`, `image_count`, and, for
 per-image log lines, an `image_index` (1-based position within the

--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -32,21 +32,22 @@ import (
 )
 
 var (
-	noPGI             = flag.Bool("no-public-good", false, "disable public good sigstore instance")
-	certsDir          = flag.String("certs", "", "Directory to where TLS certs are stored")
-	trustDomains      = flag.String("trust-domain", "", "comma separated trust domains to use")
-	tufRepo           = flag.String("tuf-repo", "", "URL to TUF repository")
-	tufRoot           = flag.String("tuf-root", "", "Path to a root.json used to initialize TUF repository")
-	tufTargets        = flag.String("tuf-targets", "", "Comma separated list of targets to load as trust roots")
-	ns                = flag.String("namespace", "", "namespace the pod runs in")
-	ips               = flag.String("image-pull-secret", "", "the imagePullSecret to use for private registries")
-	port              = flag.String("port", "8080", "port to listen to")
-	metricsPort       = flag.String("metrics-port", "9090", "port to listen to for metrics")
-	bundleMaxAttempts = flag.Int("bundle-max-attempts", 3, "max attempts to fetch a bundle")
-	bundleTimeout     = flag.Duration("bundle-timeout", 3*time.Second, "timeout for a single attempt to fetch a bundle")
-	bundleDelay       = flag.Duration("bundle-delay", 0, "delay between attempts to fetch a bundle")
-	bundleCacheTTL    = flag.Duration("bundle-cache-ttl", 60*time.Second, "TTL for the in-memory bundle cache; 0 disables caching")
-	updateCABundle    = flag.Bool("update-ca-bundle", false, "regularly update the Provider's caBundle field")
+	noPGI                 = flag.Bool("no-public-good", false, "disable public good sigstore instance")
+	certsDir              = flag.String("certs", "", "Directory to where TLS certs are stored")
+	trustDomains          = flag.String("trust-domain", "", "comma separated trust domains to use")
+	tufRepo               = flag.String("tuf-repo", "", "URL to TUF repository")
+	tufRoot               = flag.String("tuf-root", "", "Path to a root.json used to initialize TUF repository")
+	tufTargets            = flag.String("tuf-targets", "", "Comma separated list of targets to load as trust roots")
+	ns                    = flag.String("namespace", "", "namespace the pod runs in")
+	ips                   = flag.String("image-pull-secret", "", "the imagePullSecret to use for private registries")
+	port                  = flag.String("port", "8080", "port to listen to")
+	metricsPort           = flag.String("metrics-port", "9090", "port to listen to for metrics")
+	bundleMaxAttempts     = flag.Int("bundle-max-attempts", 3, "max attempts to fetch a bundle")
+	bundleTimeout         = flag.Duration("bundle-timeout", 3*time.Second, "timeout for a single attempt to fetch a bundle")
+	bundleDelay           = flag.Duration("bundle-delay", 0, "delay between attempts to fetch a bundle")
+	bundleCacheTTL        = flag.Duration("bundle-cache-ttl", 60*time.Second, "TTL for the in-memory bundle cache; 0 disables caching")
+	bundleCacheMaxEntries = flag.Int("bundle-cache-max-entries", 4096, "max entries in the in-memory bundle cache; 0 disables the size cap (unbounded)")
+	updateCABundle        = flag.Bool("update-ca-bundle", false, "regularly update the Provider's caBundle field")
 )
 
 const (
@@ -148,8 +149,8 @@ func main() {
 	if *bundleCacheTTL > 0 {
 		// The janitor goroutine lives for the process lifetime; there is no
 		// defer Stop() here because main exits via log.Fatal on error.
-		bf = fetcher.NewCachingBundleFetcher(&fetcher.DefaultBundleFetcher{}, *bundleCacheTTL)
-		slog.Info("bundle cache enabled", "ttl", bundleCacheTTL.String())
+		bf = fetcher.NewCachingBundleFetcher(&fetcher.DefaultBundleFetcher{}, *bundleCacheTTL, *bundleCacheMaxEntries)
+		slog.Info("bundle cache enabled", "ttl", bundleCacheTTL.String(), "max_entries", *bundleCacheMaxEntries)
 	}
 	var p = provider.New(v, kc, bf)
 	var t = transport{

--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -149,9 +149,7 @@ func main() {
 	kc = authn.NewKeyChainProvider(*ns, []string{*ips})
 
 	// Singleflight de-duplication always runs; a non-positive -bundle-cache-ttl
-	// only disables the persisted time cache (see NewCachingBundleFetcher). The
-	// janitor goroutine, when started, lives for the process lifetime; there is
-	// no defer Stop() here because main exits via log.Fatal on error.
+	// only disables the persisted time cache (see NewCachingBundleFetcher).
 	var bf provider.BundleFetcher = fetcher.NewCachingBundleFetcher(
 		&fetcher.DefaultBundleFetcher{}, *bundleCacheTTL, *bundleCacheMaxEntries)
 	if *bundleCacheTTL > 0 {

--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -74,6 +74,9 @@ func main() {
 	if err := configureBundleFetcher(*bundleMaxAttempts, *bundleTimeout, *bundleDelay); err != nil {
 		log.Fatal(err)
 	}
+	if err := validateBundleCacheFlags(*bundleCacheTTL, *bundleCacheMaxEntries); err != nil {
+		log.Fatal(err)
+	}
 
 	var vCfg = app.VerifierCfg{
 		TufRoot: *tufRoot,
@@ -145,12 +148,16 @@ func main() {
 
 	kc = authn.NewKeyChainProvider(*ns, []string{*ips})
 
-	var bf provider.BundleFetcher = &fetcher.DefaultBundleFetcher{}
+	// Singleflight de-duplication always runs; a non-positive -bundle-cache-ttl
+	// only disables the persisted time cache (see NewCachingBundleFetcher). The
+	// janitor goroutine, when started, lives for the process lifetime; there is
+	// no defer Stop() here because main exits via log.Fatal on error.
+	var bf provider.BundleFetcher = fetcher.NewCachingBundleFetcher(
+		&fetcher.DefaultBundleFetcher{}, *bundleCacheTTL, *bundleCacheMaxEntries)
 	if *bundleCacheTTL > 0 {
-		// The janitor goroutine lives for the process lifetime; there is no
-		// defer Stop() here because main exits via log.Fatal on error.
-		bf = fetcher.NewCachingBundleFetcher(&fetcher.DefaultBundleFetcher{}, *bundleCacheTTL, *bundleCacheMaxEntries)
 		slog.Info("bundle cache enabled", "ttl", bundleCacheTTL.String(), "max_entries", *bundleCacheMaxEntries)
+	} else {
+		slog.Info("bundle cache disabled; singleflight de-duplication only")
 	}
 	var p = provider.New(v, kc, bf)
 	var t = transport{
@@ -211,6 +218,20 @@ func configureBundleFetcher(maxAttempts int, timeout, delay time.Duration) error
 	fetcher.MaxAttempts = maxAttempts
 	fetcher.Timeout = timeout
 	fetcher.Delay = delay
+	return nil
+}
+
+// validateBundleCacheFlags rejects nonsensical bundle-cache flag values. A ttl
+// of 0 is valid and means "singleflight only" (time cache disabled); a
+// max-entries of 0 is valid and means "unbounded". Negative values are not a
+// meaningful configuration, so they are rejected rather than silently coerced.
+func validateBundleCacheFlags(ttl time.Duration, maxEntries int) error {
+	if ttl < 0 {
+		return errors.New("bundle-cache-ttl must not be negative")
+	}
+	if maxEntries < 0 {
+		return errors.New("bundle-cache-max-entries must not be negative")
+	}
 	return nil
 }
 

--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -45,6 +45,7 @@ var (
 	bundleMaxAttempts = flag.Int("bundle-max-attempts", 3, "max attempts to fetch a bundle")
 	bundleTimeout     = flag.Duration("bundle-timeout", 3*time.Second, "timeout for a single attempt to fetch a bundle")
 	bundleDelay       = flag.Duration("bundle-delay", 0, "delay between attempts to fetch a bundle")
+	bundleCacheTTL    = flag.Duration("bundle-cache-ttl", 60*time.Second, "TTL for the in-memory bundle cache; 0 disables caching")
 	updateCABundle    = flag.Bool("update-ca-bundle", false, "regularly update the Provider's caBundle field")
 )
 
@@ -142,7 +143,15 @@ func main() {
 	}
 
 	kc = authn.NewKeyChainProvider(*ns, []string{*ips})
-	var p = provider.New(v, kc, &fetcher.DefaultBundleFetcher{})
+
+	var bf provider.BundleFetcher = &fetcher.DefaultBundleFetcher{}
+	if *bundleCacheTTL > 0 {
+		// The janitor goroutine lives for the process lifetime; there is no
+		// defer Stop() here because main exits via log.Fatal on error.
+		bf = fetcher.NewCachingBundleFetcher(&fetcher.DefaultBundleFetcher{}, *bundleCacheTTL)
+		slog.Info("bundle cache enabled", "ttl", bundleCacheTTL.String())
+	}
+	var p = provider.New(v, kc, bf)
 	var t = transport{
 		p: p,
 	}

--- a/cmd/aaop/aaop_test.go
+++ b/cmd/aaop/aaop_test.go
@@ -77,3 +77,50 @@ func TestConfigureBundleFetcherRejectsInvalidValues(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBundleCacheFlags(t *testing.T) {
+	// 0 is valid for both flags: ttl=0 means "singleflight only" (time cache
+	// disabled) and max-entries=0 means "unbounded". Positive values are valid.
+	cases := []struct {
+		name       string
+		ttl        time.Duration
+		maxEntries int
+	}{
+		{"zero ttl and zero max", 0, 0},
+		{"positive ttl and max", 60 * time.Second, 4096},
+		{"zero ttl, positive max", 0, 100},
+		{"positive ttl, zero max", 30 * time.Second, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, validateBundleCacheFlags(tc.ttl, tc.maxEntries))
+		})
+	}
+}
+
+func TestValidateBundleCacheFlagsRejectsNegatives(t *testing.T) {
+	tests := []struct {
+		name       string
+		ttl        time.Duration
+		maxEntries int
+		errorText  string
+	}{
+		{
+			name:      "negative ttl",
+			ttl:       -time.Second,
+			errorText: "bundle-cache-ttl must not be negative",
+		},
+		{
+			name:       "negative max entries",
+			ttl:        time.Second,
+			maxEntries: -1,
+			errorText:  "bundle-cache-max-entries must not be negative",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateBundleCacheFlags(test.ttl, test.maxEntries)
+			require.EqualError(t, err, test.errorText)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/sigstore/sigstore-go v1.3.0
 	github.com/stretchr/testify v1.12.0
+	golang.org/x/sync v0.22.0
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 )
@@ -134,7 +135,6 @@ require (
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20250310182122-79a9477fa575
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
+	github.com/sigstore/protobuf-specs v0.5.1
 	github.com/sigstore/sigstore-go v1.3.0
 	github.com/stretchr/testify v1.12.0
 	golang.org/x/sync v0.22.0
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 )
@@ -112,7 +114,6 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.11.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
-	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/rekor v1.5.3 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.3.0 // indirect
 	github.com/sigstore/sigstore v1.10.8 // indirect
@@ -142,7 +143,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect
 	google.golang.org/grpc v1.82.1 // indirect
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/fetcher/cache.go
+++ b/pkg/fetcher/cache.go
@@ -1,0 +1,199 @@
+package fetcher
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sigstore/sigstore-go/pkg/bundle"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/github/artifact-attestations-opa-provider/pkg/metrics"
+)
+
+// bundleFetcher is the behavior CachingBundleFetcher decorates. It matches the
+// provider's BundleFetcher interface so a CachingBundleFetcher can be dropped in
+// wherever a DefaultBundleFetcher is used.
+type bundleFetcher interface {
+	BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, error)
+	GetRemoteOptions(kc authn.Keychain) []remote.Option
+}
+
+type cacheEntry struct {
+	bundles []*bundle.Bundle
+	hash    *v1.Hash
+	expires time.Time
+}
+
+// CachingBundleFetcher decorates a bundle fetcher with a short-TTL result cache
+// and singleflight de-duplication.
+//
+// Admission bursts (e.g. a workload rolling out across many clusters at once)
+// produce many concurrent validations for the *same* image. Without this
+// decorator each one makes its own OCI round-trip, and that concurrent load is
+// what overwhelms the registry and pushes fetches past the admission timeout.
+//
+// The cache serves repeat validations of a stable digest from memory, and
+// singleflight collapses a burst of concurrent identical fetches into a single
+// upstream request whose result is shared with every waiter.
+type CachingBundleFetcher struct {
+	inner bundleFetcher
+	ttl   time.Duration
+
+	group singleflight.Group
+
+	mu    sync.RWMutex
+	cache map[string]cacheEntry
+
+	// now and stop are here to keep the type testable (injectable clock) and
+	// to allow the background janitor to be shut down cleanly.
+	now  func() time.Time
+	stop chan struct{}
+	once sync.Once
+}
+
+// NewCachingBundleFetcher wraps inner with a cache whose entries live for ttl.
+// A background janitor evicts expired entries every ttl. Call Stop to release it.
+func NewCachingBundleFetcher(inner bundleFetcher, ttl time.Duration) *CachingBundleFetcher {
+	return newCachingBundleFetcher(inner, ttl, time.Now, true)
+}
+
+// newCachingBundleFetcher is the test-friendly constructor: it allows injecting
+// a clock and skipping the background janitor.
+func newCachingBundleFetcher(inner bundleFetcher, ttl time.Duration, now func() time.Time, runJanitor bool) *CachingBundleFetcher {
+	c := &CachingBundleFetcher{
+		inner: inner,
+		ttl:   ttl,
+		cache: make(map[string]cacheEntry),
+		now:   now,
+		stop:  make(chan struct{}),
+	}
+	if runJanitor {
+		go c.janitor(ttl)
+	}
+	return c
+}
+
+// GetRemoteOptions delegates to the wrapped fetcher.
+func (c *CachingBundleFetcher) GetRemoteOptions(kc authn.Keychain) []remote.Option {
+	return c.inner.GetRemoteOptions(kc)
+}
+
+// BundleFromName returns the bundles for ref, serving them from the cache when
+// possible and otherwise de-duplicating concurrent fetches for the same ref.
+func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+	key := ref.Name()
+
+	if e, ok := c.load(key); ok {
+		metrics.BundleCacheHits.Inc()
+		return e.bundles, e.hash, nil
+	}
+	metrics.BundleCacheMisses.Inc()
+
+	ch := c.group.DoChan(key, func() (any, error) {
+		// Another caller may have populated the cache while this call queued.
+		if e, ok := c.load(key); ok {
+			return e, nil
+		}
+
+		// Detach from the triggering caller's cancellation so the shared fetch
+		// can run to completion and warm the cache even if that caller's
+		// admission request is already cancelled. The inner fetcher bounds the
+		// work with its own per-attempt timeout and retry budget.
+		fctx := context.WithoutCancel(ctx)
+
+		b, h, err := c.inner.BundleFromName(fctx, ref, ro)
+		if err != nil {
+			// Do not cache failures: the next request should retry.
+			return nil, err
+		}
+
+		e := cacheEntry{bundles: b, hash: h, expires: c.now().Add(c.ttl)}
+		c.store(key, e)
+		return e, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		// This caller gave up (typically the admission timeout). The shared
+		// fetch above keeps running and may still populate the cache for
+		// subsequent callers.
+		return nil, nil, &FetchError{
+			Kind:        kindFromContext(ctx.Err()),
+			Recoverable: false,
+			Err:         ctx.Err(),
+		}
+	case res := <-ch:
+		if res.Shared {
+			metrics.BundleFetchDeduped.Inc()
+		}
+		if res.Err != nil {
+			return nil, nil, res.Err
+		}
+		e, ok := res.Val.(cacheEntry)
+		if !ok {
+			return nil, nil, &FetchError{
+				Kind:        KindUnknown,
+				Recoverable: false,
+				Err:         errors.New("bundle cache: unexpected value type"),
+			}
+		}
+		return e.bundles, e.hash, nil
+	}
+}
+
+// Stop shuts down the background janitor. It is safe to call more than once.
+func (c *CachingBundleFetcher) Stop() {
+	c.once.Do(func() { close(c.stop) })
+}
+
+func (c *CachingBundleFetcher) load(key string) (cacheEntry, bool) {
+	c.mu.RLock()
+	e, ok := c.cache[key]
+	c.mu.RUnlock()
+	if !ok || !c.now().Before(e.expires) {
+		return cacheEntry{}, false
+	}
+	return e, true
+}
+
+func (c *CachingBundleFetcher) store(key string, e cacheEntry) {
+	c.mu.Lock()
+	c.cache[key] = e
+	n := len(c.cache)
+	c.mu.Unlock()
+	metrics.BundleCacheEntries.Set(float64(n))
+}
+
+func (c *CachingBundleFetcher) janitor(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.sweep()
+		}
+	}
+}
+
+func (c *CachingBundleFetcher) sweep() {
+	now := c.now()
+	c.mu.Lock()
+	for k, e := range c.cache {
+		if !now.Before(e.expires) {
+			delete(c.cache, k)
+		}
+	}
+	n := len(c.cache)
+	c.mu.Unlock()
+	metrics.BundleCacheEntries.Set(float64(n))
+	slog.Debug("bundle cache swept", "entries", n)
+}

--- a/pkg/fetcher/cache.go
+++ b/pkg/fetcher/cache.go
@@ -51,6 +51,11 @@ type CachingBundleFetcher struct {
 	// means unbounded.
 	maxEntries int
 
+	// cacheEnabled reports whether the persisted time cache is active (ttl > 0).
+	// When false, singleflight still de-duplicates concurrent fetches, but no
+	// entries are read, stored, or swept and the janitor does not run.
+	cacheEnabled bool
+
 	group singleflight.Group
 
 	mu    sync.RWMutex
@@ -63,9 +68,12 @@ type CachingBundleFetcher struct {
 	once sync.Once
 }
 
-// NewCachingBundleFetcher wraps inner with a cache whose entries live for ttl
-// and is bounded to maxEntries (0 = unbounded). A background janitor evicts
-// expired entries every ttl. Call Stop to release it.
+// NewCachingBundleFetcher wraps inner with a short-TTL, digest-keyed result
+// cache (bounded to maxEntries; 0 = unbounded) fronted by singleflight
+// de-duplication. Singleflight always runs; a ttl <= 0 disables the persisted
+// time cache (and its janitor) while keeping singleflight active. When the time
+// cache is enabled a background janitor evicts expired entries every ttl; call
+// Stop to release it.
 func NewCachingBundleFetcher(inner bundleFetcher, ttl time.Duration, maxEntries int) *CachingBundleFetcher {
 	return newCachingBundleFetcher(inner, ttl, maxEntries, time.Now, true)
 }
@@ -74,14 +82,17 @@ func NewCachingBundleFetcher(inner bundleFetcher, ttl time.Duration, maxEntries 
 // a clock and skipping the background janitor.
 func newCachingBundleFetcher(inner bundleFetcher, ttl time.Duration, maxEntries int, now func() time.Time, runJanitor bool) *CachingBundleFetcher {
 	c := &CachingBundleFetcher{
-		inner:      inner,
-		ttl:        ttl,
-		maxEntries: maxEntries,
-		cache:      make(map[string]cacheEntry),
-		now:        now,
-		stop:       make(chan struct{}),
+		inner:        inner,
+		ttl:          ttl,
+		maxEntries:   maxEntries,
+		cacheEnabled: ttl > 0,
+		cache:        make(map[string]cacheEntry),
+		now:          now,
+		stop:         make(chan struct{}),
 	}
-	if runJanitor {
+	// Only run the janitor when the time cache is active: nothing is ever stored
+	// otherwise, and time.NewTicker panics on a non-positive interval.
+	if runJanitor && c.cacheEnabled {
 		go c.janitor(ttl)
 	}
 	return c
@@ -109,7 +120,11 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 	// persisted time cache.
 	_, isDigest := ref.(name.Digest)
 
-	if isDigest {
+	// timeCacheable reports whether this call may use the persisted time cache:
+	// the cache must be enabled (ttl > 0) and the reference must be a digest.
+	timeCacheable := isDigest && c.cacheEnabled
+
+	if timeCacheable {
 		if e, ok := c.load(key); ok {
 			metrics.BundleCacheHits.Inc()
 			return e.bundles, e.hash, nil
@@ -117,9 +132,27 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 		metrics.BundleCacheMisses.Inc()
 	}
 
+	// leader is set (inside the singleflight closure) only for the one call
+	// whose closure actually runs. singleflight marks the result Shared for
+	// *every* recipient including that leader, so leader lets us attribute a
+	// dedupe only to the joiners: an N-caller flight records N-1 dedupes.
+	leader := false
+
+	// Singleflight is keyed on the requested reference and always runs,
+	// independent of the time cache. For a tag it shares the leader's
+	// tag->digest resolution with every joiner in the in-flight window, so a
+	// joiner whose tag moved mid-flight receives the leader's digest. That
+	// window is bounded by a single fetch and is subsumed by the inherent, much
+	// larger admission->kubelet-pull TOCTOU present for ANY mutable-tag
+	// admission, so it does not change the security posture in kind. Keeping
+	// singleflight on tags is deliberate: collapsing the tag->digest resolve
+	// storm is the dominant cost this decorator exists to fix. Use digest
+	// references (or registry-enforced tag immutability) for a strong binding.
 	ch := c.group.DoChan(key, func() (any, error) {
+		leader = true
+
 		// Another caller may have populated the cache while this call queued.
-		if isDigest {
+		if timeCacheable {
 			if e, ok := c.load(key); ok {
 				return e, nil
 			}
@@ -138,19 +171,22 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 		}
 
 		e := cacheEntry{bundles: b, hash: h, expires: c.now().Add(c.ttl)}
-		switch {
-		case isDigest:
-			c.store(key, e)
-		case h != nil:
-			// The requested reference is a tag, which is never served from the
-			// time cache. The resolved digest, however, is content-addressed and
-			// safe, so warm a digest-keyed entry: a later request that arrives
-			// *by digest* can then be served from the cache. Reads still only
-			// happen for digest-input refs above, so this never serves a tag.
-			c.store(ref.Context().Digest(h.String()).Name(), e)
-		default:
-			// A tag ref that resolved to no attestations (nil hash): there is
-			// nothing content-addressed to key on, so nothing is cached.
+		if c.cacheEnabled {
+			switch {
+			case isDigest:
+				c.store(key, e)
+			case h != nil:
+				// The requested reference is a tag, which is never served from
+				// the time cache. The resolved digest, however, is
+				// content-addressed and safe, so warm a digest-keyed entry: a
+				// later request that arrives *by digest* can then be served.
+				// Reads still only happen for digest-input refs above, so this
+				// never serves a tag.
+				c.store(ref.Context().Digest(h.String()).Name(), e)
+			default:
+				// A tag ref that resolved to no attestations (nil hash): there
+				// is nothing content-addressed to key on, so nothing is cached.
+			}
 		}
 		return e, nil
 	})
@@ -166,7 +202,9 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 			Err:         ctx.Err(),
 		}
 	case res := <-ch:
-		if res.Shared {
+		// Shared is true for every recipient including the leader; only the
+		// joiners were actually de-duplicated, so exclude the leader.
+		if res.Shared && !leader {
 			metrics.BundleFetchDeduped.Inc()
 		}
 		if res.Err != nil {
@@ -208,13 +246,14 @@ func (c *CachingBundleFetcher) store(key string, e cacheEntry) {
 		evicted = true
 	}
 	c.cache[key] = e
-	n := len(c.cache)
+	// Publish the gauge while still holding the lock so concurrent mutations
+	// update it in the same serialized order in which they mutate the map.
+	metrics.BundleCacheEntries.Set(float64(len(c.cache)))
 	c.mu.Unlock()
 
 	if evicted {
 		metrics.BundleCacheEvictions.Inc()
 	}
-	metrics.BundleCacheEntries.Set(float64(n))
 }
 
 // evictSoonestToExpireLocked removes the entry with the earliest expiry. The
@@ -259,7 +298,8 @@ func (c *CachingBundleFetcher) sweep() {
 		}
 	}
 	n := len(c.cache)
-	c.mu.Unlock()
+	// Publish the gauge under the lock so it matches the serialized mutation.
 	metrics.BundleCacheEntries.Set(float64(n))
+	c.mu.Unlock()
 	slog.Debug("bundle cache swept", "entries", n)
 }

--- a/pkg/fetcher/cache.go
+++ b/pkg/fetcher/cache.go
@@ -46,6 +46,11 @@ type CachingBundleFetcher struct {
 	inner bundleFetcher
 	ttl   time.Duration
 
+	// maxEntries bounds the size of the time cache. When it is >0 and the cache
+	// is full, storing a new key first evicts the soonest-to-expire entry. 0
+	// means unbounded.
+	maxEntries int
+
 	group singleflight.Group
 
 	mu    sync.RWMutex
@@ -58,21 +63,23 @@ type CachingBundleFetcher struct {
 	once sync.Once
 }
 
-// NewCachingBundleFetcher wraps inner with a cache whose entries live for ttl.
-// A background janitor evicts expired entries every ttl. Call Stop to release it.
-func NewCachingBundleFetcher(inner bundleFetcher, ttl time.Duration) *CachingBundleFetcher {
-	return newCachingBundleFetcher(inner, ttl, time.Now, true)
+// NewCachingBundleFetcher wraps inner with a cache whose entries live for ttl
+// and is bounded to maxEntries (0 = unbounded). A background janitor evicts
+// expired entries every ttl. Call Stop to release it.
+func NewCachingBundleFetcher(inner bundleFetcher, ttl time.Duration, maxEntries int) *CachingBundleFetcher {
+	return newCachingBundleFetcher(inner, ttl, maxEntries, time.Now, true)
 }
 
 // newCachingBundleFetcher is the test-friendly constructor: it allows injecting
 // a clock and skipping the background janitor.
-func newCachingBundleFetcher(inner bundleFetcher, ttl time.Duration, now func() time.Time, runJanitor bool) *CachingBundleFetcher {
+func newCachingBundleFetcher(inner bundleFetcher, ttl time.Duration, maxEntries int, now func() time.Time, runJanitor bool) *CachingBundleFetcher {
 	c := &CachingBundleFetcher{
-		inner: inner,
-		ttl:   ttl,
-		cache: make(map[string]cacheEntry),
-		now:   now,
-		stop:  make(chan struct{}),
+		inner:      inner,
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		cache:      make(map[string]cacheEntry),
+		now:        now,
+		stop:       make(chan struct{}),
 	}
 	if runJanitor {
 		go c.janitor(ttl)
@@ -90,16 +97,32 @@ func (c *CachingBundleFetcher) GetRemoteOptions(kc authn.Keychain) []remote.Opti
 func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
 	key := ref.Name()
 
-	if e, ok := c.load(key); ok {
-		metrics.BundleCacheHits.Inc()
-		return e.bundles, e.hash, nil
+	// The persisted time cache is digest-only. OCI tags are mutable: a registry
+	// can repoint a tag to a new digest within the TTL window, so serving a tag
+	// from a persisted entry could return a verification result for a digest the
+	// tag no longer points to -> an admission bypass. Digest references are
+	// content-addressed and cannot move, so they are always safe to cache. This
+	// property must hold in ANY environment, so we gate purely on the reference
+	// type and never on tag-naming conventions. Tag references still get
+	// singleflight de-duplication below (concurrent-only coalescing is safe
+	// regardless of tag mutability); they simply never read from or write to the
+	// persisted time cache.
+	_, isDigest := ref.(name.Digest)
+
+	if isDigest {
+		if e, ok := c.load(key); ok {
+			metrics.BundleCacheHits.Inc()
+			return e.bundles, e.hash, nil
+		}
+		metrics.BundleCacheMisses.Inc()
 	}
-	metrics.BundleCacheMisses.Inc()
 
 	ch := c.group.DoChan(key, func() (any, error) {
 		// Another caller may have populated the cache while this call queued.
-		if e, ok := c.load(key); ok {
-			return e, nil
+		if isDigest {
+			if e, ok := c.load(key); ok {
+				return e, nil
+			}
 		}
 
 		// Detach from the triggering caller's cancellation so the shared fetch
@@ -115,7 +138,20 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 		}
 
 		e := cacheEntry{bundles: b, hash: h, expires: c.now().Add(c.ttl)}
-		c.store(key, e)
+		switch {
+		case isDigest:
+			c.store(key, e)
+		case h != nil:
+			// The requested reference is a tag, which is never served from the
+			// time cache. The resolved digest, however, is content-addressed and
+			// safe, so warm a digest-keyed entry: a later request that arrives
+			// *by digest* can then be served from the cache. Reads still only
+			// happen for digest-input refs above, so this never serves a tag.
+			c.store(ref.Context().Digest(h.String()).Name(), e)
+		default:
+			// A tag ref that resolved to no attestations (nil hash): there is
+			// nothing content-addressed to key on, so nothing is cached.
+		}
 		return e, nil
 	})
 
@@ -165,10 +201,40 @@ func (c *CachingBundleFetcher) load(key string) (cacheEntry, bool) {
 
 func (c *CachingBundleFetcher) store(key string, e cacheEntry) {
 	c.mu.Lock()
+	_, exists := c.cache[key]
+	evicted := false
+	if !exists && c.maxEntries > 0 && len(c.cache) >= c.maxEntries {
+		c.evictSoonestToExpireLocked()
+		evicted = true
+	}
 	c.cache[key] = e
 	n := len(c.cache)
 	c.mu.Unlock()
+
+	if evicted {
+		metrics.BundleCacheEvictions.Inc()
+	}
 	metrics.BundleCacheEntries.Set(float64(n))
+}
+
+// evictSoonestToExpireLocked removes the entry with the earliest expiry. The
+// caller must hold c.mu. Evicting the soonest-to-expire entry is a cheap,
+// dependency-free approximation of LRU that keeps the longest-lived entries and
+// bounds memory without pulling in a cache library.
+func (c *CachingBundleFetcher) evictSoonestToExpireLocked() {
+	var (
+		victim  string
+		soonest time.Time
+		found   bool
+	)
+	for k, e := range c.cache {
+		if !found || e.expires.Before(soonest) {
+			victim, soonest, found = k, e.expires, true
+		}
+	}
+	if found {
+		delete(c.cache, victim)
+	}
 }
 
 func (c *CachingBundleFetcher) janitor(interval time.Duration) {

--- a/pkg/fetcher/cache.go
+++ b/pkg/fetcher/cache.go
@@ -112,12 +112,23 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 	// can repoint a tag to a new digest within the TTL window, so serving a tag
 	// from a persisted entry could return a verification result for a digest the
 	// tag no longer points to -> an admission bypass. Digest references are
-	// content-addressed and cannot move, so they are always safe to cache. This
-	// property must hold in ANY environment, so we gate purely on the reference
-	// type and never on tag-naming conventions. Tag references still get
-	// singleflight de-duplication below (concurrent-only coalescing is safe
-	// regardless of tag mutability); they simply never read from or write to the
-	// persisted time cache.
+	// content-addressed, so digest-keying guarantees a moved tag can never
+	// substitute a *different image*.
+	//
+	// That guarantee bounds image identity, not the attestation set: the
+	// referrers for a digest are mutable, so a cached positive result can be up
+	// to one TTL stale with respect to attestations added or removed for that
+	// digest (in particular, attestation-removal-as-revocation is not reflected
+	// until the entry expires). Re-verification on a hit re-checks the cached
+	// material against the current trust root but does not re-fetch the referrer
+	// set; "no attestations" results are not cached (see below), so a
+	// newly-published attestation is picked up on the next validation.
+	//
+	// The digest-only rule must hold in ANY environment, so we gate purely on
+	// the reference type and never on tag-naming conventions. Tag references
+	// still get singleflight de-duplication below (concurrent-only coalescing is
+	// safe regardless of tag mutability); they simply never read from or write
+	// to the persisted time cache.
 	_, isDigest := ref.(name.Digest)
 
 	// timeCacheable reports whether this call may use the persisted time cache:
@@ -130,6 +141,20 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 			return e.bundles, e.hash, nil
 		}
 		metrics.BundleCacheMisses.Inc()
+	}
+
+	// If the caller is already cancelled (e.g. a timed-out multi-image
+	// Provider.Validate that keeps looping over its remaining keys), do not
+	// start a new detached fetch: it would spawn orphaned registry work under
+	// the very herd this decorator exists to relieve. A cache hit above is still
+	// served because it is free; only a dead request that missed is stopped
+	// here, mirroring the mid-flight cancellation handling below.
+	if err := ctx.Err(); err != nil {
+		return nil, nil, &FetchError{
+			Kind:        kindFromContext(err),
+			Recoverable: false,
+			Err:         err,
+		}
 	}
 
 	// leader is set (inside the singleflight closure) only for the one call
@@ -171,21 +196,27 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 		}
 
 		e := cacheEntry{bundles: b, hash: h, expires: c.now().Add(c.ttl)}
-		if c.cacheEnabled {
+		// Only cache positive results. A digest with no referrers resolves to
+		// (nil, nil, nil); caching that would pin "no attestations" for the
+		// whole TTL even after one is later published, because the referrer set
+		// is mutable even though the digest is immutable. We still return e
+		// below so this request reports no attestations, but we do not persist
+		// it: the next validation re-fetches and picks up a new attestation.
+		if c.cacheEnabled && len(b) > 0 {
 			switch {
 			case isDigest:
 				c.store(key, e)
 			case h != nil:
 				// The requested reference is a tag, which is never served from
 				// the time cache. The resolved digest, however, is
-				// content-addressed and safe, so warm a digest-keyed entry: a
-				// later request that arrives *by digest* can then be served.
-				// Reads still only happen for digest-input refs above, so this
-				// never serves a tag.
+				// content-addressed, so warm a digest-keyed entry: a later
+				// request that arrives *by digest* can then be served. Reads
+				// still only happen for digest-input refs above, so this never
+				// serves a tag.
 				c.store(ref.Context().Digest(h.String()).Name(), e)
 			default:
-				// A tag ref that resolved to no attestations (nil hash): there
-				// is nothing content-addressed to key on, so nothing is cached.
+				// Unreachable: len(b) > 0 implies a resolved digest hash (h is
+				// non-nil). Present only to satisfy switch-style linting.
 			}
 		}
 		return e, nil

--- a/pkg/fetcher/cache.go
+++ b/pkg/fetcher/cache.go
@@ -271,6 +271,14 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 			metrics.BundleFetchDeduped.Inc()
 		}
 		if res.Err != nil {
+			// An errored fetch is still an upstream-backed miss (e.g. a
+			// registry outage). Count it so failures don't undercount misses
+			// and inflate the apparent hit ratio. Gate on timeCacheable to
+			// match the success path; cancellations are handled separately and
+			// are never counted as a cache outcome.
+			if timeCacheable {
+				metrics.BundleCacheMisses.Inc()
+			}
 			return nil, nil, res.Err
 		}
 		fr, ok := res.Val.(flightResult)

--- a/pkg/fetcher/cache.go
+++ b/pkg/fetcher/cache.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -26,9 +27,23 @@ type bundleFetcher interface {
 }
 
 type cacheEntry struct {
-	bundles []*bundle.Bundle
-	hash    *v1.Hash
-	expires time.Time
+	// serialized holds the bundles in their immutable marshalled form. The
+	// cache never stores []*bundle.Bundle: sigstore-go memoizes verification
+	// state on the *bundle.Bundle receiver, so handing the same instance to two
+	// concurrent verifications is a data race. Each caller unmarshals its own
+	// private copy from these bytes.
+	serialized [][]byte
+	hash       *v1.Hash
+	expires    time.Time
+}
+
+// flightResult is the singleflight closure's return value: the immutable cache
+// entry plus whether the closure was served from a concurrently-populated cache
+// entry (fromCache) rather than a fresh upstream fetch. It lets each recipient
+// account a hit vs a miss once the source is known.
+type flightResult struct {
+	entry     cacheEntry
+	fromCache bool
 }
 
 // CachingBundleFetcher decorates a bundle fetcher with a short-TTL result cache
@@ -138,9 +153,18 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 	if timeCacheable {
 		if e, ok := c.load(key); ok {
 			metrics.BundleCacheHits.Inc()
-			return e.bundles, e.hash, nil
+			// Unmarshal a private copy: sigstore-go memoizes verification state
+			// on the *bundle.Bundle receiver, so no two callers may share one.
+			bundles, err := deserializeBundles(e.serialized)
+			if err != nil {
+				return nil, nil, cacheCodecError(err)
+			}
+			return bundles, e.hash, nil
 		}
-		metrics.BundleCacheMisses.Inc()
+		// Do not count a miss yet. A concurrent flight may still populate the
+		// entry via the second-chance lookup below, in which case this request
+		// is really a hit; the hit/miss decision is made once the source of the
+		// result is known (see the singleflight result handling further down).
 	}
 
 	// If the caller is already cancelled (e.g. a timed-out multi-image
@@ -179,7 +203,7 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 		// Another caller may have populated the cache while this call queued.
 		if timeCacheable {
 			if e, ok := c.load(key); ok {
-				return e, nil
+				return flightResult{entry: e, fromCache: true}, nil
 			}
 		}
 
@@ -195,14 +219,22 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 			return nil, err
 		}
 
-		e := cacheEntry{bundles: b, hash: h, expires: c.now().Add(c.ttl)}
+		// Cache the immutable serialized form, never []*bundle.Bundle: every
+		// recipient below unmarshals its own private copy, so concurrent
+		// verifications cannot write memoized state onto a shared *bundle.Bundle.
+		ser, err := serializeBundles(b)
+		if err != nil {
+			return nil, cacheCodecError(err)
+		}
+
+		e := cacheEntry{serialized: ser, hash: h, expires: c.now().Add(c.ttl)}
 		// Only cache positive results. A digest with no referrers resolves to
 		// (nil, nil, nil); caching that would pin "no attestations" for the
 		// whole TTL even after one is later published, because the referrer set
 		// is mutable even though the digest is immutable. We still return e
 		// below so this request reports no attestations, but we do not persist
 		// it: the next validation re-fetches and picks up a new attestation.
-		if c.cacheEnabled && len(b) > 0 {
+		if c.cacheEnabled && len(ser) > 0 {
 			switch {
 			case isDigest:
 				c.store(key, e)
@@ -215,11 +247,11 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 				// serves a tag.
 				c.store(ref.Context().Digest(h.String()).Name(), e)
 			default:
-				// Unreachable: len(b) > 0 implies a resolved digest hash (h is
+				// Unreachable: len(ser) > 0 implies a resolved digest hash (h is
 				// non-nil). Present only to satisfy switch-style linting.
 			}
 		}
-		return e, nil
+		return flightResult{entry: e, fromCache: false}, nil
 	})
 
 	select {
@@ -241,7 +273,7 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 		if res.Err != nil {
 			return nil, nil, res.Err
 		}
-		e, ok := res.Val.(cacheEntry)
+		fr, ok := res.Val.(flightResult)
 		if !ok {
 			return nil, nil, &FetchError{
 				Kind:        KindUnknown,
@@ -249,7 +281,23 @@ func (c *CachingBundleFetcher) BundleFromName(ctx context.Context, ref name.Refe
 				Err:         errors.New("bundle cache: unexpected value type"),
 			}
 		}
-		return e.bundles, e.hash, nil
+		// Now that the source is known, account the outcome: a result served
+		// from the (possibly concurrently-populated) time cache is a hit; one
+		// backed by a fresh upstream fetch is a miss. Only digest requests
+		// consult the time cache, so only they are counted.
+		if timeCacheable {
+			if fr.fromCache {
+				metrics.BundleCacheHits.Inc()
+			} else {
+				metrics.BundleCacheMisses.Inc()
+			}
+		}
+		// Unmarshal a private copy per caller (see the hit path above).
+		bundles, err := deserializeBundles(fr.entry.serialized)
+		if err != nil {
+			return nil, nil, cacheCodecError(err)
+		}
+		return bundles, fr.entry.hash, nil
 	}
 }
 
@@ -333,4 +381,48 @@ func (c *CachingBundleFetcher) sweep() {
 	metrics.BundleCacheEntries.Set(float64(n))
 	c.mu.Unlock()
 	slog.Debug("bundle cache swept", "entries", n)
+}
+
+// serializeBundles marshals bundles to their immutable JSON form for caching.
+// The cache stores bytes rather than *bundle.Bundle so that each caller can be
+// given a private, freshly-unmarshalled copy (see deserializeBundles).
+func serializeBundles(bundles []*bundle.Bundle) ([][]byte, error) {
+	serialized := make([][]byte, len(bundles))
+	for i, b := range bundles {
+		data, err := b.MarshalJSON()
+		if err != nil {
+			return nil, fmt.Errorf("bundle cache: marshalling bundle: %w", err)
+		}
+		serialized[i] = data
+	}
+	return serialized, nil
+}
+
+// deserializeBundles unmarshals cached bytes into a fresh set of bundles, one
+// private instance per caller. sigstore-go memoizes verification state (e.g.
+// inclusion-proof/promise flags) on the *bundle.Bundle receiver during
+// verification, so callers that verify concurrently must not share instances.
+// The round-trip is lossless for verification: all material lives in the proto
+// and the memoized flags are recomputed per verification.
+func deserializeBundles(serialized [][]byte) ([]*bundle.Bundle, error) {
+	bundles := make([]*bundle.Bundle, len(serialized))
+	for i, data := range serialized {
+		b := &bundle.Bundle{}
+		if err := b.UnmarshalJSON(data); err != nil {
+			return nil, fmt.Errorf("bundle cache: unmarshalling bundle: %w", err)
+		}
+		bundles[i] = b
+	}
+	return bundles, nil
+}
+
+// cacheCodecError wraps a bundle (de)serialization failure as a
+// non-recoverable FetchError so callers handle it uniformly with other fetch
+// failures.
+func cacheCodecError(err error) *FetchError {
+	return &FetchError{
+		Kind:        KindUnknown,
+		Recoverable: false,
+		Err:         err,
+	}
 }

--- a/pkg/fetcher/cache_test.go
+++ b/pkg/fetcher/cache_test.go
@@ -235,6 +235,28 @@ func TestConcurrentTagRefsSingleflightedToOneFetch(t *testing.T) {
 	assert.InDelta(t, float64(n-1), afterDeduped-beforeDeduped, 1e-9, "an N-caller flight records N-1 dedupes")
 }
 
+func TestErroredFetchCountsAsMiss(t *testing.T) {
+	inner := &fakeFetcher{err: errors.New("boom")}
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustDigestRef(t, "a")
+
+	// An errored upstream fetch for a digest is a miss and must be counted.
+	before := testutil.ToFloat64(metrics.BundleCacheMisses)
+	_, _, err := c.BundleFromName(context.Background(), ref, nil)
+	require.Error(t, err)
+	after := testutil.ToFloat64(metrics.BundleCacheMisses)
+	assert.InDelta(t, 1.0, after-before, 1e-9, "an errored digest fetch increments the miss counter")
+
+	// A cancellation is not a cache outcome and must not be counted as a miss.
+	beforeCancel := testutil.ToFloat64(metrics.BundleCacheMisses)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err = c.BundleFromName(ctx, ref, nil)
+	require.Error(t, err)
+	afterCancel := testutil.ToFloat64(metrics.BundleCacheMisses)
+	assert.InDelta(t, 0.0, afterCancel-beforeCancel, 1e-9, "a cancelled caller does not increment the miss counter")
+}
+
 func TestSingleflightRunsWithTimeCacheDisabled(t *testing.T) {
 	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
 	// ttl=0 disables the persisted time cache; singleflight must still run.

--- a/pkg/fetcher/cache_test.go
+++ b/pkg/fetcher/cache_test.go
@@ -32,6 +32,10 @@ type fakeFetcher struct {
 	// number) instead of hash. This lets a test simulate a mutable tag whose
 	// resolved digest changes between calls.
 	hashes []*v1.Hash
+	// emptyCalls is the number of leading calls that return (nil, nil, nil),
+	// simulating a digest whose referrer set is initially empty (no
+	// attestations published yet).
+	emptyCalls int32
 }
 
 func (f *fakeFetcher) BundleFromName(ctx context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
@@ -45,6 +49,10 @@ func (f *fakeFetcher) BundleFromName(ctx context.Context, _ name.Reference, _ []
 	}
 	if f.err != nil {
 		return nil, nil, f.err
+	}
+	if n <= f.emptyCalls {
+		// No referrers yet: mirror DoBundleFromName's empty-result contract.
+		return nil, nil, nil
 	}
 	h := f.hash
 	if len(f.hashes) > 0 {
@@ -344,6 +352,64 @@ func TestMaxEntriesEviction(t *testing.T) {
 
 	after := testutil.ToFloat64(metrics.BundleCacheEvictions)
 	assert.InDelta(t, 1.0, after-before, 1e-9, "exactly one eviction was recorded")
+}
+
+func TestEmptyResultNotCached(t *testing.T) {
+	// The first fetch finds no referrers; a later fetch finds a
+	// newly-published attestation.
+	inner := &fakeFetcher{emptyCalls: 1, bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustDigestRef(t, "a")
+
+	b1, _, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	assert.Empty(t, b1, "no attestations are reported on the first fetch")
+	_, ok := c.load(ref.Name())
+	assert.False(t, ok, "an empty result is not persisted in the time cache")
+
+	// Because the empty result was not cached, the next validation re-fetches
+	// and picks up the now-published attestation instead of a stale negative.
+	b2, _, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	assert.Len(t, b2, 1, "the newly-published attestation is returned")
+	assert.Equal(t, int32(2), inner.callCount(), "the digest is re-fetched because nothing was cached")
+}
+
+func TestAlreadyCancelledCallerDoesNotFetch(t *testing.T) {
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustDigestRef(t, "a")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled on arrival, with a cold cache
+
+	_, _, err := c.BundleFromName(ctx, ref, nil)
+	require.Error(t, err)
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindCanceled, fe.Kind)
+	assert.Equal(t, int32(0), inner.callCount(), "an already-cancelled caller does not start a fetch")
+}
+
+func TestAlreadyCancelledCallerStillServesCacheHit(t *testing.T) {
+	hash := &v1.Hash{Hex: "abc"}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: hash}
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustDigestRef(t, "a")
+
+	// Warm the cache with a live request.
+	_, _, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), inner.callCount())
+
+	// A cancelled caller is still served the (free) cache hit.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	b, h, err := c.BundleFromName(ctx, ref, nil)
+	require.NoError(t, err)
+	assert.Len(t, b, 1)
+	assert.Equal(t, hash, h)
+	assert.Equal(t, int32(1), inner.callCount(), "the cache hit is served without a new fetch")
 }
 
 func TestStopIsIdempotent(t *testing.T) {

--- a/pkg/fetcher/cache_test.go
+++ b/pkg/fetcher/cache_test.go
@@ -1,0 +1,185 @@
+package fetcher
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFetcher is a controllable bundleFetcher for exercising the cache.
+type fakeFetcher struct {
+	calls   int32
+	block   chan struct{} // when non-nil, BundleFromName blocks until closed
+	err     error
+	bundles []*bundle.Bundle
+	hash    *v1.Hash
+}
+
+func (f *fakeFetcher) BundleFromName(ctx context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+	atomic.AddInt32(&f.calls, 1)
+	if f.block != nil {
+		select {
+		case <-f.block:
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return f.bundles, f.hash, nil
+}
+
+func (*fakeFetcher) GetRemoteOptions(_ authn.Keychain) []remote.Option { return nil }
+
+func (f *fakeFetcher) callCount() int32 { return atomic.LoadInt32(&f.calls) }
+
+func mustRef(t *testing.T, s string) name.Reference {
+	t.Helper()
+	ref, err := name.ParseReference(s)
+	require.NoError(t, err)
+	return ref
+}
+
+func TestCacheServesRepeatFetches(t *testing.T) {
+	hash := &v1.Hash{Algorithm: "sha256", Hex: "abc"}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: hash}
+	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
+	ref := mustRef(t, "ghcr.io/o/r:v1")
+
+	for i := 0; i < 3; i++ {
+		b, h, err := c.BundleFromName(context.Background(), ref, nil)
+		require.NoError(t, err)
+		assert.Len(t, b, 1)
+		assert.Equal(t, hash, h)
+	}
+
+	assert.Equal(t, int32(1), inner.callCount(), "only the first fetch should reach the registry")
+}
+
+func TestCacheExpiresAfterTTL(t *testing.T) {
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	var mu sync.Mutex
+	clock := time.Now()
+	now := func() time.Time { mu.Lock(); defer mu.Unlock(); return clock }
+	c := newCachingBundleFetcher(inner, 100*time.Millisecond, now, false)
+	ref := mustRef(t, "ghcr.io/o/r:v1")
+
+	_, _, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	_, _, err = c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), inner.callCount(), "second call within TTL is a cache hit")
+
+	mu.Lock()
+	clock = clock.Add(200 * time.Millisecond)
+	mu.Unlock()
+
+	_, _, err = c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), inner.callCount(), "call after TTL expiry re-fetches")
+}
+
+func TestSingleflightDedupsConcurrentFetches(t *testing.T) {
+	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
+	ref := mustRef(t, "ghcr.io/o/r:v1")
+
+	const n = 25
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Go(func() {
+			_, _, errs[i] = c.BundleFromName(context.Background(), ref, nil)
+		})
+	}
+
+	// Wait for the single in-flight fetch to start, then let the rest attach.
+	require.Eventually(t, func() bool { return inner.callCount() >= 1 }, time.Second, time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+	close(inner.block)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), inner.callCount(), "a burst of concurrent fetches collapses to one")
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+}
+
+func TestErrorsAreNotCached(t *testing.T) {
+	inner := &fakeFetcher{err: errors.New("boom")}
+	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
+	ref := mustRef(t, "ghcr.io/o/r:v1")
+
+	_, _, err := c.BundleFromName(context.Background(), ref, nil)
+	require.Error(t, err)
+	_, _, err = c.BundleFromName(context.Background(), ref, nil)
+	require.Error(t, err)
+
+	assert.Equal(t, int32(2), inner.callCount(), "failed fetches are not cached and are retried")
+	_, ok := c.load(ref.Name())
+	assert.False(t, ok)
+}
+
+func TestCallerCancellationStillWarmsCache(t *testing.T) {
+	hash := &v1.Hash{Hex: "abc"}
+	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{{}}, hash: hash}
+	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
+	ref := mustRef(t, "ghcr.io/o/r:v1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		_, _, err := c.BundleFromName(ctx, ref, nil)
+		errc <- err
+	}()
+
+	// Once the (detached) shared fetch is running, the caller gives up.
+	require.Eventually(t, func() bool { return inner.callCount() == 1 }, time.Second, time.Millisecond)
+	cancel()
+
+	err := <-errc
+	require.Error(t, err)
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindCanceled, fe.Kind)
+
+	// The shared fetch keeps running; once it completes it warms the cache.
+	close(inner.block)
+	require.Eventually(t, func() bool { _, ok := c.load(ref.Name()); return ok }, time.Second, time.Millisecond)
+
+	b, h, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	assert.Len(t, b, 1)
+	assert.Equal(t, hash, h)
+	assert.Equal(t, int32(1), inner.callCount(), "the warmed cache serves the later caller without a new fetch")
+}
+
+func TestDistinctRefsFetchedSeparately(t *testing.T) {
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
+
+	_, _, err := c.BundleFromName(context.Background(), mustRef(t, "ghcr.io/o/r:v1"), nil)
+	require.NoError(t, err)
+	_, _, err = c.BundleFromName(context.Background(), mustRef(t, "ghcr.io/o/r:v2"), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), inner.callCount(), "different references are fetched independently")
+}
+
+func TestStopIsIdempotent(t *testing.T) {
+	c := NewCachingBundleFetcher(&fakeFetcher{}, time.Minute)
+	c.Stop()
+	assert.NotPanics(t, c.Stop)
+}

--- a/pkg/fetcher/cache_test.go
+++ b/pkg/fetcher/cache_test.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,9 +13,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/github/artifact-attestations-opa-provider/pkg/metrics"
 )
 
 // fakeFetcher is a controllable bundleFetcher for exercising the cache.
@@ -24,10 +28,14 @@ type fakeFetcher struct {
 	err     error
 	bundles []*bundle.Bundle
 	hash    *v1.Hash
+	// hashes, when non-empty, is returned by successive calls (indexed by call
+	// number) instead of hash. This lets a test simulate a mutable tag whose
+	// resolved digest changes between calls.
+	hashes []*v1.Hash
 }
 
 func (f *fakeFetcher) BundleFromName(ctx context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
-	atomic.AddInt32(&f.calls, 1)
+	n := atomic.AddInt32(&f.calls, 1)
 	if f.block != nil {
 		select {
 		case <-f.block:
@@ -38,7 +46,15 @@ func (f *fakeFetcher) BundleFromName(ctx context.Context, _ name.Reference, _ []
 	if f.err != nil {
 		return nil, nil, f.err
 	}
-	return f.bundles, f.hash, nil
+	h := f.hash
+	if len(f.hashes) > 0 {
+		idx := int(n - 1)
+		if idx >= len(f.hashes) {
+			idx = len(f.hashes) - 1
+		}
+		h = f.hashes[idx]
+	}
+	return f.bundles, h, nil
 }
 
 func (*fakeFetcher) GetRemoteOptions(_ authn.Keychain) []remote.Option { return nil }
@@ -52,11 +68,22 @@ func mustRef(t *testing.T, s string) name.Reference {
 	return ref
 }
 
+// mustDigestRef builds a valid, immutable digest reference, using a 64-character
+// sha256 hex made by repeating hexChar. Only digest refs are served from the
+// time cache, so cache-hit tests must use these.
+func mustDigestRef(t *testing.T, hexChar string) name.Reference {
+	t.Helper()
+	ref, err := name.ParseReference("ghcr.io/o/r@sha256:" + strings.Repeat(hexChar, 64))
+	require.NoError(t, err)
+	return ref
+}
+
 func TestCacheServesRepeatFetches(t *testing.T) {
 	hash := &v1.Hash{Algorithm: "sha256", Hex: "abc"}
 	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: hash}
-	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
-	ref := mustRef(t, "ghcr.io/o/r:v1")
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	// Digest ref: only content-addressed references are served from the cache.
+	ref := mustDigestRef(t, "a")
 
 	for i := 0; i < 3; i++ {
 		b, h, err := c.BundleFromName(context.Background(), ref, nil)
@@ -73,8 +100,8 @@ func TestCacheExpiresAfterTTL(t *testing.T) {
 	var mu sync.Mutex
 	clock := time.Now()
 	now := func() time.Time { mu.Lock(); defer mu.Unlock(); return clock }
-	c := newCachingBundleFetcher(inner, 100*time.Millisecond, now, false)
-	ref := mustRef(t, "ghcr.io/o/r:v1")
+	c := newCachingBundleFetcher(inner, 100*time.Millisecond, 0, now, false)
+	ref := mustDigestRef(t, "a")
 
 	_, _, err := c.BundleFromName(context.Background(), ref, nil)
 	require.NoError(t, err)
@@ -91,10 +118,55 @@ func TestCacheExpiresAfterTTL(t *testing.T) {
 	assert.Equal(t, int32(2), inner.callCount(), "call after TTL expiry re-fetches")
 }
 
-func TestSingleflightDedupsConcurrentFetches(t *testing.T) {
+func TestDigestRefServedFromCacheWithinTTL(t *testing.T) {
+	hash := &v1.Hash{Algorithm: "sha256", Hex: "abc"}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: hash}
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustDigestRef(t, "d")
+
+	b1, h1, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	b2, h2, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), inner.callCount(), "a digest ref is served from the time cache within the TTL")
+	assert.Equal(t, hash, h1)
+	assert.Equal(t, hash, h2)
+	assert.Len(t, b1, 1)
+	assert.Len(t, b2, 1)
+
+	_, ok := c.load(ref.Name())
+	assert.True(t, ok, "the digest ref is persisted in the time cache")
+}
+
+func TestTagRefNotServedFromTimeCache(t *testing.T) {
+	hashA := &v1.Hash{Algorithm: "sha256", Hex: "aaa"}
+	hashB := &v1.Hash{Algorithm: "sha256", Hex: "bbb"}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hashes: []*v1.Hash{hashA, hashB}}
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustRef(t, "ghcr.io/o/r:v1") // a mutable tag
+
+	_, h1, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	assert.Equal(t, hashA, h1)
+
+	// The tag has been repointed to a new digest. A second call within the TTL
+	// must re-fetch (tag refs are never served from the time cache) and observe
+	// the new digest, never a stale cached result.
+	_, h2, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), inner.callCount(), "a tag ref is re-fetched, never served from the time cache")
+	assert.Equal(t, hashB, h2, "the second call reflects the moved tag, not a stale entry")
+
+	// The tag itself is never persisted under its own key.
+	_, ok := c.load(ref.Name())
+	assert.False(t, ok, "a tag ref is not stored in the time cache under its tag key")
+}
+
+func TestConcurrentTagRefsSingleflightedToOneFetch(t *testing.T) {
 	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
-	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
-	ref := mustRef(t, "ghcr.io/o/r:v1")
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustRef(t, "ghcr.io/o/r:v1") // a tag
 
 	const n = 25
 	var wg sync.WaitGroup
@@ -111,7 +183,9 @@ func TestSingleflightDedupsConcurrentFetches(t *testing.T) {
 	close(inner.block)
 	wg.Wait()
 
-	assert.Equal(t, int32(1), inner.callCount(), "a burst of concurrent fetches collapses to one")
+	// Even though tag refs are never time-cached, a concurrent burst of the same
+	// tag still collapses to a single upstream fetch via singleflight.
+	assert.Equal(t, int32(1), inner.callCount(), "a burst of concurrent tag fetches collapses to one")
 	for _, err := range errs {
 		assert.NoError(t, err)
 	}
@@ -119,8 +193,8 @@ func TestSingleflightDedupsConcurrentFetches(t *testing.T) {
 
 func TestErrorsAreNotCached(t *testing.T) {
 	inner := &fakeFetcher{err: errors.New("boom")}
-	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
-	ref := mustRef(t, "ghcr.io/o/r:v1")
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustDigestRef(t, "a")
 
 	_, _, err := c.BundleFromName(context.Background(), ref, nil)
 	require.Error(t, err)
@@ -135,8 +209,8 @@ func TestErrorsAreNotCached(t *testing.T) {
 func TestCallerCancellationStillWarmsCache(t *testing.T) {
 	hash := &v1.Hash{Hex: "abc"}
 	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{{}}, hash: hash}
-	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
-	ref := mustRef(t, "ghcr.io/o/r:v1")
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustDigestRef(t, "a")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errc := make(chan error, 1)
@@ -168,18 +242,56 @@ func TestCallerCancellationStillWarmsCache(t *testing.T) {
 
 func TestDistinctRefsFetchedSeparately(t *testing.T) {
 	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
-	c := newCachingBundleFetcher(inner, time.Minute, time.Now, false)
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 
-	_, _, err := c.BundleFromName(context.Background(), mustRef(t, "ghcr.io/o/r:v1"), nil)
+	_, _, err := c.BundleFromName(context.Background(), mustDigestRef(t, "a"), nil)
 	require.NoError(t, err)
-	_, _, err = c.BundleFromName(context.Background(), mustRef(t, "ghcr.io/o/r:v2"), nil)
+	_, _, err = c.BundleFromName(context.Background(), mustDigestRef(t, "b"), nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(2), inner.callCount(), "different references are fetched independently")
 }
 
+func TestMaxEntriesEviction(t *testing.T) {
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "x"}}
+	var mu sync.Mutex
+	clock := time.Now()
+	now := func() time.Time { mu.Lock(); defer mu.Unlock(); return clock }
+	c := newCachingBundleFetcher(inner, time.Hour, 2, now, false)
+
+	before := testutil.ToFloat64(metrics.BundleCacheEvictions)
+
+	// Store three distinct digest refs, advancing the clock between each so the
+	// first-inserted entry has the earliest expiry and is the eviction victim.
+	refs := []name.Reference{
+		mustDigestRef(t, "a"),
+		mustDigestRef(t, "b"),
+		mustDigestRef(t, "c"),
+	}
+	for _, ref := range refs {
+		_, _, err := c.BundleFromName(context.Background(), ref, nil)
+		require.NoError(t, err)
+		mu.Lock()
+		clock = clock.Add(time.Second)
+		mu.Unlock()
+	}
+
+	c.mu.RLock()
+	n := len(c.cache)
+	_, hasFirst := c.cache[refs[0].Name()]
+	_, hasLast := c.cache[refs[2].Name()]
+	c.mu.RUnlock()
+
+	assert.Equal(t, 2, n, "the cache is bounded to maxEntries")
+	assert.False(t, hasFirst, "the soonest-to-expire entry (first inserted) is evicted")
+	assert.True(t, hasLast, "the most recently inserted entry is retained")
+
+	after := testutil.ToFloat64(metrics.BundleCacheEvictions)
+	assert.InDelta(t, 1.0, after-before, 1e-9, "exactly one eviction was recorded")
+}
+
 func TestStopIsIdempotent(t *testing.T) {
-	c := NewCachingBundleFetcher(&fakeFetcher{}, time.Minute)
+	c := NewCachingBundleFetcher(&fakeFetcher{}, time.Minute, 0)
 	c.Stop()
 	assert.NotPanics(t, c.Stop)
 }

--- a/pkg/fetcher/cache_test.go
+++ b/pkg/fetcher/cache_test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/github/artifact-attestations-opa-provider/pkg/metrics"
 )
@@ -86,9 +89,35 @@ func mustDigestRef(t *testing.T, hexChar string) name.Reference {
 	return ref
 }
 
+// testBundle builds a minimal but valid sigstore bundle that survives the
+// cache's marshal/unmarshal round-trip. It has no tlog entries (so it needs no
+// inclusion proof/promise) and uses a v0.2 media type. The cache stores bundles
+// as bytes, so tests must supply real bundles rather than zero-value ones.
+func testBundle(t *testing.T) *bundle.Bundle {
+	t.Helper()
+	mediaType, err := bundle.MediaTypeString("0.2")
+	require.NoError(t, err)
+	pb := &protobundle.Bundle{
+		MediaType: mediaType,
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_PublicKey{
+				PublicKey: &protocommon.PublicKeyIdentifier{Hint: "test-key"},
+			},
+		},
+		Content: &protobundle.Bundle_MessageSignature{
+			MessageSignature: &protocommon.MessageSignature{
+				Signature: []byte("test-signature"),
+			},
+		},
+	}
+	b, err := bundle.NewBundle(pb)
+	require.NoError(t, err)
+	return b
+}
+
 func TestCacheServesRepeatFetches(t *testing.T) {
 	hash := &v1.Hash{Algorithm: "sha256", Hex: "abc"}
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: hash}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: hash}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	// Digest ref: only content-addressed references are served from the cache.
 	ref := mustDigestRef(t, "a")
@@ -104,7 +133,7 @@ func TestCacheServesRepeatFetches(t *testing.T) {
 }
 
 func TestCacheExpiresAfterTTL(t *testing.T) {
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
 	var mu sync.Mutex
 	clock := time.Now()
 	now := func() time.Time { mu.Lock(); defer mu.Unlock(); return clock }
@@ -128,7 +157,7 @@ func TestCacheExpiresAfterTTL(t *testing.T) {
 
 func TestDigestRefServedFromCacheWithinTTL(t *testing.T) {
 	hash := &v1.Hash{Algorithm: "sha256", Hex: "abc"}
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: hash}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: hash}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	ref := mustDigestRef(t, "d")
 
@@ -150,7 +179,7 @@ func TestDigestRefServedFromCacheWithinTTL(t *testing.T) {
 func TestTagRefNotServedFromTimeCache(t *testing.T) {
 	hashA := &v1.Hash{Algorithm: "sha256", Hex: "aaa"}
 	hashB := &v1.Hash{Algorithm: "sha256", Hex: "bbb"}
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hashes: []*v1.Hash{hashA, hashB}}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hashes: []*v1.Hash{hashA, hashB}}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	ref := mustRef(t, "ghcr.io/o/r:v1") // a mutable tag
 
@@ -172,7 +201,7 @@ func TestTagRefNotServedFromTimeCache(t *testing.T) {
 }
 
 func TestConcurrentTagRefsSingleflightedToOneFetch(t *testing.T) {
-	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	ref := mustRef(t, "ghcr.io/o/r:v1") // a tag
 
@@ -207,7 +236,7 @@ func TestConcurrentTagRefsSingleflightedToOneFetch(t *testing.T) {
 }
 
 func TestSingleflightRunsWithTimeCacheDisabled(t *testing.T) {
-	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
 	// ttl=0 disables the persisted time cache; singleflight must still run.
 	c := newCachingBundleFetcher(inner, 0, 0, time.Now, false)
 	// Even a digest ref is not time-cached when the cache is disabled.
@@ -234,7 +263,7 @@ func TestSingleflightRunsWithTimeCacheDisabled(t *testing.T) {
 }
 
 func TestTimeCacheDisabledDigestNotServed(t *testing.T) {
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
 	c := newCachingBundleFetcher(inner, 0, 0, time.Now, false)
 	ref := mustDigestRef(t, "a")
 
@@ -272,7 +301,7 @@ func TestErrorsAreNotCached(t *testing.T) {
 
 func TestCallerCancellationStillWarmsCache(t *testing.T) {
 	hash := &v1.Hash{Hex: "abc"}
-	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{{}}, hash: hash}
+	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{testBundle(t)}, hash: hash}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	ref := mustDigestRef(t, "a")
 
@@ -305,7 +334,7 @@ func TestCallerCancellationStillWarmsCache(t *testing.T) {
 }
 
 func TestDistinctRefsFetchedSeparately(t *testing.T) {
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 
 	_, _, err := c.BundleFromName(context.Background(), mustDigestRef(t, "a"), nil)
@@ -317,7 +346,7 @@ func TestDistinctRefsFetchedSeparately(t *testing.T) {
 }
 
 func TestMaxEntriesEviction(t *testing.T) {
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "x"}}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "x"}}
 	var mu sync.Mutex
 	clock := time.Now()
 	now := func() time.Time { mu.Lock(); defer mu.Unlock(); return clock }
@@ -357,7 +386,7 @@ func TestMaxEntriesEviction(t *testing.T) {
 func TestEmptyResultNotCached(t *testing.T) {
 	// The first fetch finds no referrers; a later fetch finds a
 	// newly-published attestation.
-	inner := &fakeFetcher{emptyCalls: 1, bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	inner := &fakeFetcher{emptyCalls: 1, bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	ref := mustDigestRef(t, "a")
 
@@ -376,7 +405,7 @@ func TestEmptyResultNotCached(t *testing.T) {
 }
 
 func TestAlreadyCancelledCallerDoesNotFetch(t *testing.T) {
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	ref := mustDigestRef(t, "a")
 
@@ -393,7 +422,7 @@ func TestAlreadyCancelledCallerDoesNotFetch(t *testing.T) {
 
 func TestAlreadyCancelledCallerStillServesCacheHit(t *testing.T) {
 	hash := &v1.Hash{Hex: "abc"}
-	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: hash}
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: hash}
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	ref := mustDigestRef(t, "a")
 
@@ -410,6 +439,62 @@ func TestAlreadyCancelledCallerStillServesCacheHit(t *testing.T) {
 	assert.Len(t, b, 1)
 	assert.Equal(t, hash, h)
 	assert.Equal(t, int32(1), inner.callCount(), "the cache hit is served without a new fetch")
+}
+
+func TestConcurrentCallersGetDistinctBundleInstances(t *testing.T) {
+	// Regression test for a data race: the cache must never hand the same
+	// *bundle.Bundle to two callers, because sigstore-go memoizes verification
+	// state on the receiver during verification. Runs under -race.
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{testBundle(t)}, hash: &v1.Hash{Hex: "abc"}}
+	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
+	ref := mustDigestRef(t, "a")
+
+	const n = 25
+	var wg sync.WaitGroup
+	got := make([][]*bundle.Bundle, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Go(func() {
+			b, _, err := c.BundleFromName(context.Background(), ref, nil)
+			errs[i] = err
+			// Exercise the memoized-write path the way verification does; on
+			// distinct instances this is race-free.
+			for _, bnd := range b {
+				_, _ = bnd.TlogEntries()
+			}
+			got[i] = b
+		})
+	}
+	wg.Wait()
+
+	// Every caller must have received its own bundle instances, whether it was
+	// served from the singleflight result or from a subsequent cache hit.
+	seen := make(map[*bundle.Bundle]struct{})
+	for i := 0; i < n; i++ {
+		require.NoError(t, errs[i])
+		require.Len(t, got[i], 1)
+		b := got[i][0]
+		_, dup := seen[b]
+		assert.Falsef(t, dup, "caller %d received a *bundle.Bundle already handed to another caller", i)
+		seen[b] = struct{}{}
+	}
+	assert.Len(t, seen, n, "each caller received a distinct bundle instance")
+}
+
+func TestSerializeDeserializeRoundTrip(t *testing.T) {
+	orig := testBundle(t)
+
+	serialized, err := serializeBundles([]*bundle.Bundle{orig})
+	require.NoError(t, err)
+	require.Len(t, serialized, 1)
+
+	got, err := deserializeBundles(serialized)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.NotSame(t, orig, got[0], "deserialization returns a fresh instance")
+	assert.True(t, proto.Equal(orig.Bundle, got[0].Bundle),
+		"the round-trip preserves the verification-relevant bundle content")
 }
 
 func TestStopIsIdempotent(t *testing.T) {

--- a/pkg/fetcher/cache_test.go
+++ b/pkg/fetcher/cache_test.go
@@ -168,6 +168,8 @@ func TestConcurrentTagRefsSingleflightedToOneFetch(t *testing.T) {
 	c := newCachingBundleFetcher(inner, time.Minute, 0, time.Now, false)
 	ref := mustRef(t, "ghcr.io/o/r:v1") // a tag
 
+	beforeDeduped := testutil.ToFloat64(metrics.BundleFetchDeduped)
+
 	const n = 25
 	var wg sync.WaitGroup
 	errs := make([]error, n)
@@ -187,8 +189,62 @@ func TestConcurrentTagRefsSingleflightedToOneFetch(t *testing.T) {
 	// tag still collapses to a single upstream fetch via singleflight.
 	assert.Equal(t, int32(1), inner.callCount(), "a burst of concurrent tag fetches collapses to one")
 	for _, err := range errs {
+		require.NoError(t, err)
+	}
+
+	// singleflight marks the result Shared for every recipient including the
+	// leader, but only the N-1 joiners were actually de-duplicated.
+	afterDeduped := testutil.ToFloat64(metrics.BundleFetchDeduped)
+	assert.InDelta(t, float64(n-1), afterDeduped-beforeDeduped, 1e-9, "an N-caller flight records N-1 dedupes")
+}
+
+func TestSingleflightRunsWithTimeCacheDisabled(t *testing.T) {
+	inner := &fakeFetcher{block: make(chan struct{}), bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	// ttl=0 disables the persisted time cache; singleflight must still run.
+	c := newCachingBundleFetcher(inner, 0, 0, time.Now, false)
+	// Even a digest ref is not time-cached when the cache is disabled.
+	ref := mustDigestRef(t, "a")
+
+	const n = 10
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Go(func() {
+			_, _, errs[i] = c.BundleFromName(context.Background(), ref, nil)
+		})
+	}
+
+	require.Eventually(t, func() bool { return inner.callCount() >= 1 }, time.Second, time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+	close(inner.block)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), inner.callCount(), "concurrent fetches collapse to one even with the time cache disabled")
+	for _, err := range errs {
 		assert.NoError(t, err)
 	}
+}
+
+func TestTimeCacheDisabledDigestNotServed(t *testing.T) {
+	inner := &fakeFetcher{bundles: []*bundle.Bundle{{}}, hash: &v1.Hash{Hex: "abc"}}
+	c := newCachingBundleFetcher(inner, 0, 0, time.Now, false)
+	ref := mustDigestRef(t, "a")
+
+	_, _, err := c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+	_, _, err = c.BundleFromName(context.Background(), ref, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), inner.callCount(), "with the time cache disabled, a repeat digest fetch is not served from cache")
+	_, ok := c.load(ref.Name())
+	assert.False(t, ok, "nothing is stored when the time cache is disabled")
+}
+
+func TestNewWithZeroTTLDoesNotStartJanitor(t *testing.T) {
+	// ttl=0 must not start the janitor: time.NewTicker panics on a
+	// non-positive interval, and there is nothing to sweep.
+	c := NewCachingBundleFetcher(&fakeFetcher{}, 0, 0)
+	assert.NotPanics(t, c.Stop)
 }
 
 func TestErrorsAreNotCached(t *testing.T) {

--- a/pkg/metrics/prom.go
+++ b/pkg/metrics/prom.go
@@ -84,4 +84,10 @@ var (
 		Name: "aaop_bundle_cache_entries",
 		Help: "The current number of entries in the in-memory bundle cache",
 	})
+
+	//nolint: revive
+	BundleCacheEvictions = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "aaop_bundle_cache_evictions_total",
+		Help: "The total number of bundle cache entries evicted due to the size cap",
+	})
 )

--- a/pkg/metrics/prom.go
+++ b/pkg/metrics/prom.go
@@ -60,4 +60,28 @@ var (
 		Help:    "The number of images (keys) included in a single provider request",
 		Buckets: []float64{1, 2, 3, 5, 10, 20, 50},
 	})
+
+	//nolint: revive
+	BundleCacheHits = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "aaop_bundle_cache_hits_total",
+		Help: "The total number of bundle fetches served from the in-memory cache",
+	})
+
+	//nolint: revive
+	BundleCacheMisses = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "aaop_bundle_cache_misses_total",
+		Help: "The total number of bundle fetches not served from the in-memory cache",
+	})
+
+	//nolint: revive
+	BundleFetchDeduped = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "aaop_bundle_fetch_deduped_total",
+		Help: "The total number of bundle fetches de-duplicated by singleflight (shared with an in-flight fetch)",
+	})
+
+	//nolint: revive
+	BundleCacheEntries = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "aaop_bundle_cache_entries",
+		Help: "The current number of entries in the in-memory bundle cache",
+	})
 )


### PR DESCRIPTION
## Summary

Front the OCI bundle fetch with [singleflight](https://pkg.go.dev/golang.org/x/sync/singleflight) de-duplication and a short-TTL, **digest-only** in-memory cache, so that repeated and concurrent validations of the same image no longer each perform a full registry round-trip. This reduces the redundant registry load that can push attestation fetches past the admission webhook timeout.

Today `Provider.Validate` re-fetches bundles and re-runs verification on every request — even for an image validated moments earlier, and even when many identical requests arrive at once.

## Failure modes this addresses

- **Concurrent duplicate fetches during rollouts (thundering herd).** When a workload rolls out, many pods are admitted within a short window and each admission triggers a *separate, uncached* fetch for the *same* image. That concurrent load adds latency at the registry and can push fetches past the admission webhook deadline, cancelling the request mid-fetch. → **Singleflight** collapses concurrent fetches for the same reference into a single upstream request whose result is shared with every waiter, removing the duplicate load that causes the latency.
- **Redundant repeat validations.** Gatekeeper validates the same long-running images repeatedly — at admission and during audit — re-fetching and re-verifying each time. → A **short-TTL cache** serves repeat validations of the same digest from memory.
- **Wasted work when the caller has already timed out.** If the admission request is cancelled at the webhook deadline, a fetch bound to that request's context is cancelled with it, so nothing is cached and the retry repeats the work. → The de-duplicated fetch runs **detached** from the caller's cancellation, so it completes and warms the cache for the retry that follows.

## What this PR does

`fetcher.CachingBundleFetcher` decorates the OCI fetch with two mechanisms that have **different correctness properties**:

- **Singleflight — keyed on the requested reference.** Concurrent fetches for the same reference collapse into one shared upstream request, so a burst of identical admissions makes a single upstream call. This is the reliability fix for the herd. Coalescing shares the leader's result among the joined callers; for tag references that means sharing the leader's tag→digest resolution for the duration of one in-flight fetch — an intentional, bounded trade-off described under **Design decision** below.
- **Short-TTL time cache — keyed on the resolved digest (digest-only).** OCI tags are mutable: a tag can be repointed to a new digest within the TTL window. Serving a tag from a persisted entry could therefore return a verification result for a digest the tag no longer points to — an **admission bypass**. So the time cache only ever stores and serves **digest** references. Tag references are still de-duplicated by singleflight but are **never** time-cached; a successful tag fetch only warms a digest-keyed entry that a later by-digest request can reuse. This guarantee is independent of any deployment's tag conventions or registry behavior — it is gated purely on the reference type. Note it bounds image *identity*, not the attestation set: the referrer set for a digest is mutable, so a cached positive result can be up to one TTL stale with respect to attestations being **added or removed** (removal used as revocation is not reflected until expiry). "No attestations" results are **not** cached, so a newly-published attestation is picked up on the next validation.
- **Detached shared fetch.** A fetch that has already begun runs on `context.WithoutCancel(ctx)` so it completes and warms the cache even if the triggering caller's admission was cancelled mid-flight. A request that is *already* cancelled on arrival serves a cache hit if one exists but does **not** start a new fetch — so a timed-out multi-image `Validate` cannot spawn orphaned registry work. The inner fetcher's per-attempt timeout and retry budget still bound it.
- **Bounded size.** The cache is capped; when full, storing a new entry evicts the soonest-to-expire one (dependency-free).
- **Verification is never cached.** Failed fetches are not cached, and verification still runs on **every** call in `Provider.Validate`. The cache operates at the fetcher layer and returns `{bundles, digest}`, never a verdict — so cryptographic / trust-root revocation is re-checked on every hit. (Registry-side attestation *removal* is a referrer-set change and is only reflected once the entry expires — see the digest bullet above.)
- **No shared mutable state across concurrent verifications.** The cache stores bundles in their immutable **serialized** form and hands every consumer — each cache hit and each singleflight recipient — a freshly-unmarshalled copy, so concurrent validations of the same digest never share a `*bundle.Bundle` instance (sigstore-go memoizes verification state on the bundle receiver, which would otherwise be an unsynchronized write).

## Design decision: tag references & singleflight (reviewed, intentional)

Singleflight is keyed on the requested reference, tags included. This was raised in review as a potential tag-mutation bypass; it is a deliberate, bounded trade-off, documented here so it isn't re-litigated:

- **No verification result is ever persisted against a tag.** The time cache is digest-only, so nothing keyed on a mutable tag survives beyond a single in-flight request.
- **Singleflight only coalesces concurrent in-flight requests.** Joiners share the leader's tag→digest resolution for the duration of one fetch (bounded by the fetch timeout). If a tag is repointed mid-flight, a joiner can receive the leader's digest instead of re-resolving on its own.
- **That window is subsumed by the inherent admission→kubelet-pull TOCTOU.** For *any* mutable-tag admission, the kubelet resolves the tag at pull time, independently of what the provider validated — so a tag that moves after admission already yields "validated A, running B" regardless of caching or singleflight. Coalescing only shifts the reference instant by at most one fetch duration, strictly inside that pre-existing gap; it does not change the security posture in kind.
- **Restricting singleflight to digests was considered and rejected.** It would close this narrow window but reintroduce the concurrent tag→digest *resolve* storm that is the dominant source of the fetch timeouts this change targets — resolving each tag independently is exactly the load we are trying to collapse.
- **Strong binding** (running image == validated image) is obtained by referencing images **by digest**, or by enforcing registry tag-immutability. That is independent of this cache and is the correct control for deployments that need it.

## Configuration

- `-bundle-cache-ttl` — result cache TTL. Default `60s`; `0` disables the time cache (singleflight de-duplication stays active).
- `-bundle-cache-max-entries` — maximum cached entries. Default `4096`; `0` = unbounded. Negative values for either flag are rejected at startup.

## Metrics

- `aaop_bundle_cache_hits_total`, `aaop_bundle_cache_misses_total` — digest lookups only; an errored upstream fetch counts as a miss.
- `aaop_bundle_fetch_deduped_total` — joined (non-leader) callers served by an in-flight singleflight leader.
- `aaop_bundle_cache_entries` — current cache size.
- `aaop_bundle_cache_evictions_total` — capacity evictions.

## Scope and limitations

- The cache is **per-process and in-memory**. It de-duplicates within a single provider instance; it does not coordinate across replicas or clusters, so the more provider replicas a deployment runs, the thinner requests spread and the lower the per-instance hit rate.
- It is **defense-in-depth**, not a substitute for an adequate admission webhook `timeoutSeconds`. Where fetch latency under load is the root cause, raising the webhook timeout addresses the cancellation directly and independently of load; this PR reduces the load that produces that latency in the first place. The two are complementary.

## Testing

- `go build ./...` ✅
- `go test ./... -race` ✅ — digest cache hit + TTL expiry; **tag references are not served from the time cache** (a moved tag re-fetches); **concurrent tag references are singleflighted** into a single fetch; singleflight still de-duplicates when the time cache is disabled (`ttl=0`); **a digest with no attestations is not cached** (a later-published attestation is seen on the next call); **a request cancelled on arrival serves a cache hit but starts no fetch**; **every caller receives a distinct, freshly-unmarshalled bundle set** (no shared `*bundle.Bundle` across concurrent verifications); serialize↔deserialize round-trips losslessly; errors are not cached; an errored upstream fetch counts as a miss; a mid-flight cancelled caller still warms the cache; max-entries eviction increments the evictions metric; negative flags are rejected; distinct references; idempotent `Stop`.
- `golangci-lint run ./...` ✅ 0 issues.

## Open questions for reviewers

- **Default values** — `-bundle-cache-ttl` (`60s`) and `-bundle-cache-max-entries` (`4096`) are starting points; open to tuning.
- **Singleflight is always on.** The tag-coalescing trade-off is covered in **Design decision** above; let me know if you'd nonetheless prefer it gated behind a flag.

## Follow-ups

- Expose the cache flags via the Helm chart, and keep the registry-fetch metrics (`aaop_attestations_retrieved_*`) uncontaminated by cache hits — tracked in #202.