### PR TITLE
Add optional concurrent per-image verification

### DIFF
--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -45,6 +45,7 @@ var (
 	bundleMaxAttempts = flag.Int("bundle-max-attempts", 3, "max attempts to fetch a bundle")
 	bundleTimeout     = flag.Duration("bundle-timeout", 3*time.Second, "timeout for a single attempt to fetch a bundle")
 	bundleDelay       = flag.Duration("bundle-delay", 0, "delay between attempts to fetch a bundle")
+	imageConcurrency  = flag.Int("image-concurrency", 1, "maximum number of images to verify concurrently within a single request; 1 (default) preserves serial per-image processing")
 	updateCABundle    = flag.Bool("update-ca-bundle", false, "regularly update the Provider's caBundle field")
 )
 
@@ -71,6 +72,9 @@ func main() {
 	flag.Parse()
 	if err := configureBundleFetcher(*bundleMaxAttempts, *bundleTimeout, *bundleDelay); err != nil {
 		log.Fatal(err)
+	}
+	if *imageConcurrency < 1 {
+		log.Fatal("image-concurrency must be greater than zero")
 	}
 
 	var vCfg = app.VerifierCfg{
@@ -142,7 +146,7 @@ func main() {
 	}
 
 	kc = authn.NewKeyChainProvider(*ns, []string{*ips})
-	var p = provider.New(v, kc, &fetcher.DefaultBundleFetcher{})
+	var p = provider.New(v, kc, &fetcher.DefaultBundleFetcher{}, provider.WithConcurrency(*imageConcurrency))
 	var t = transport{
 		p: p,
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -152,6 +153,21 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 			sem <- struct{}{}
 			wg.Go(func() {
 				defer func() { <-sem }()
+				// Recover panics from the pluggable fetcher/verifier here.
+				// The serial path runs in the HTTP request goroutine, where
+				// net/http recovers per-request panics; a panic in this child
+				// goroutine would instead crash the whole provider process.
+				// Convert it into the image's system error so one malformed
+				// request or dependency panic cannot take the provider down.
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("validate: recovered panic while verifying image",
+							"image", key,
+							"panic", r,
+							"stack", string(debug.Stack()))
+						sysErrs[i] = fmt.Sprintf("ERROR: panic verifying %q: %v", key, r)
+					}
+				}()
 				items[i], sysErrs[i] = p.validateImage(ctx, key, ro)
 			})
 		}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -59,10 +59,13 @@ type Option func(*Provider)
 // parallelized; each image still fetches its own attestation bundles serially.
 // Values less than 1 are treated as 1.
 func WithConcurrency(n int) Option {
+	// Normalize here so the returned closure only reads n. This keeps applying
+	// an Option side-effect free, so the same Option is safe to reuse across
+	// concurrent New calls without racing on captured state.
+	if n < 1 {
+		n = 1
+	}
 	return func(p *Provider) {
-		if n < 1 {
-			n = 1
-		}
 		p.concurrency = n
 	}
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -42,18 +43,43 @@ type BundleFetcher interface {
 // Provider is the implementation for the OPA Gatekeeper external data
 // provider.
 type Provider struct {
-	v  Verifier
-	kc KeyChainProvider
-	bf BundleFetcher
+	v           Verifier
+	kc          KeyChainProvider
+	bf          BundleFetcher
+	concurrency int
 }
 
-// New initializes a Provider with a verifier and a keychain provider.
-func New(v Verifier, k KeyChainProvider, bf BundleFetcher) *Provider {
-	return &Provider{
-		v:  v,
-		kc: k,
-		bf: bf,
+// Option configures optional Provider behavior.
+type Option func(*Provider)
+
+// WithConcurrency sets the maximum number of images that are verified
+// concurrently within a single request. A value of 1 (the default) preserves
+// the original serial per-image processing. Only the outer, per-image loop is
+// parallelized; each image still fetches its own attestation bundles serially.
+// Values less than 1 are treated as 1.
+func WithConcurrency(n int) Option {
+	return func(p *Provider) {
+		if n < 1 {
+			n = 1
+		}
+		p.concurrency = n
 	}
+}
+
+// New initializes a Provider with a verifier and a keychain provider. By
+// default images within a request are verified serially; pass WithConcurrency
+// to verify multiple images in parallel.
+func New(v Verifier, k KeyChainProvider, bf BundleFetcher, opts ...Option) *Provider {
+	p := &Provider{
+		v:           v,
+		kc:          k,
+		bf:          bf,
+		concurrency: 1,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // Validate implements the OPA Gatekeeper external data provider per
@@ -65,7 +91,6 @@ func New(v Verifier, k KeyChainProvider, bf BundleFetcher) *Provider {
 // This means that during verification, no identity is verified, only that
 // cryptographic properties holds up given the configured trust roots.
 func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest) *externaldata.ProviderResponse {
-	var results = []externaldata.Item{}
 	var resp = externaldata.ProviderResponse{
 		APIVersion: apiVersion,
 		Kind:       "ProviderResponse",
@@ -89,106 +114,160 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 	}
 	var ro = p.bf.GetRemoteOptions(kc)
 
-	// iterate over all image references (keys)
-	for _, key := range r.Request.Keys {
-		var res []*verify.VerificationResult
-		var ref name.Reference
+	var keys = r.Request.Keys
+	var items = make([]externaldata.Item, len(keys))
+	// A non-empty entry signals a request-level system error (a verification
+	// failure) raised while processing the image at the same index.
+	var sysErrs = make([]string, len(keys))
 
-		slog.Info("validate: verify signature",
-			"image", key)
-		if ref, err = name.ParseReference(key); err != nil {
-			slog.Error("validate: error parsing reference",
-				"image", key,
-				"error", err)
-			results = append(results, externaldata.Item{
-				Key:   key,
-				Error: "invalid_reference",
-			})
-			continue
+	// Determine the effective per-request image concurrency. A value of 1
+	// preserves the original serial behavior; higher values verify the
+	// request's images in parallel using a bounded worker pool. Only this
+	// outer, per-image loop is parallelized -- each image still fetches its
+	// own attestation bundles serially, on the shared request context.
+	var concurrency = p.concurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	if concurrency > len(keys) {
+		concurrency = len(keys)
+	}
+
+	if concurrency <= 1 {
+		// Serial path: verify images one at a time and, as before, abort the
+		// whole request on the first verification (system) error.
+		for i, key := range keys {
+			items[i], sysErrs[i] = p.validateImage(ctx, key, ro)
+			if sysErrs[i] != "" {
+				return ErrorResponse(sysErrs[i])
+			}
 		}
-
-		start := time.Now()
-		bundles, hash, err := p.bf.BundleFromName(ctx, ref, ro)
-		dur := time.Since(start)
-		// Record the fetch latency for both successful and failed fetches.
-		// The tail of this histogram (failed fetches timing out) is a key
-		// signal when troubleshooting registry latency, so it must include
-		// failures.
-		metrics.AttestationsPullTimer.Observe(dur.Seconds())
-
-		if err != nil {
-			reason, step, attempts := fetcher.Classify(err)
-			metrics.AttestationsRetrieveFail.WithLabelValues(reason).Inc()
-			slog.Error("validate: error fetching bundles",
-				"image", key,
-				"reason", reason,
-				"step", step,
-				"attempts", attempts,
-				"duration_s", dur.Seconds(),
-				"error", err)
-			results = append(results, externaldata.Item{
-				Key:   key,
-				Error: "error_fetching_bundle_" + reason,
-			})
-			continue
-		}
-
-		metrics.AttestationsRetrieved.Add(float64(len(bundles)))
-		slog.Info("validate: fetched OCI bundles",
-			"image", key,
-			"count", len(bundles),
-			"duration_s", dur.Seconds())
-
-		if len(bundles) == 0 {
-			metrics.AttestationsMissing.Inc()
-			slog.Info("validate: no bundles",
-				"image", key)
-			results = append(results, externaldata.Item{
-				Key:   key,
-				Error: "image_unsigned",
-			})
-			continue
-		}
-
-		start = time.Now()
-		res, err = p.v.Verify(bundles, hash)
-		dur = time.Since(start)
-		metrics.AttestationsVerTimer.Observe(dur.Seconds())
-		metrics.AttestationsVerOk.Add(float64(len(res)))
-		var fail = len(bundles) - len(res)
-		if fail > 0 {
-			metrics.AttestationsVerFail.Add(float64(fail))
-		}
-
-		if err != nil {
-			slog.Error("validate: verification error",
-				"image", key,
-				"image_digest", hash.Hex,
-				"error", err)
-			return ErrorResponse(fmt.Sprintf("ERROR: VerifyImageSignatures(%q): %v", key, err))
-		}
-
-		var bundleVerified = len(res) > 0
-		if bundleVerified {
-			slog.Info("validate: found valid signatures",
-				"count", len(res),
-				"image", key)
-			results = append(results, externaldata.Item{
-				Key:   key,
-				Value: res,
-			})
-		} else {
-			slog.Info("validate: no valid signatures",
-				"image", key)
-			results = append(results, externaldata.Item{
-				Key:   key,
-				Error: "invalid_signature",
+	} else {
+		var wg sync.WaitGroup
+		// Bounded semaphore caps the number of images in flight at once.
+		var sem = make(chan struct{}, concurrency)
+		for i, key := range keys {
+			// Acquire a slot before launching so no more than `concurrency`
+			// images are verified at the same time.
+			sem <- struct{}{}
+			wg.Go(func() {
+				defer func() { <-sem }()
+				items[i], sysErrs[i] = p.validateImage(ctx, key, ro)
 			})
 		}
+		wg.Wait()
+	}
+
+	// Assemble the response in the original key order. A verification error
+	// for any image yields a system error response for the whole request; the
+	// first such error in key order wins so the result is deterministic
+	// regardless of serial or parallel execution.
+	var results = make([]externaldata.Item, 0, len(keys))
+	for i := range keys {
+		if sysErrs[i] != "" {
+			return ErrorResponse(sysErrs[i])
+		}
+		results = append(results, items[i])
 	}
 
 	resp.Response.Items = results
 	return &resp
+}
+
+// validateImage verifies a single image reference and returns the externaldata
+// item to include in the response. A non-empty second return value indicates a
+// request-level system error (a verification failure) that must abort the
+// entire request; in that case the returned item is empty.
+func (p *Provider) validateImage(ctx context.Context, key string, ro []remote.Option) (externaldata.Item, string) {
+	slog.Info("validate: verify signature",
+		"image", key)
+
+	ref, err := name.ParseReference(key)
+	if err != nil {
+		slog.Error("validate: error parsing reference",
+			"image", key,
+			"error", err)
+		return externaldata.Item{
+			Key:   key,
+			Error: "invalid_reference",
+		}, ""
+	}
+
+	start := time.Now()
+	bundles, hash, err := p.bf.BundleFromName(ctx, ref, ro)
+	dur := time.Since(start)
+	// Record the fetch latency for both successful and failed fetches.
+	// The tail of this histogram (failed fetches timing out) is a key
+	// signal when troubleshooting registry latency, so it must include
+	// failures.
+	metrics.AttestationsPullTimer.Observe(dur.Seconds())
+
+	if err != nil {
+		reason, step, attempts := fetcher.Classify(err)
+		metrics.AttestationsRetrieveFail.WithLabelValues(reason).Inc()
+		slog.Error("validate: error fetching bundles",
+			"image", key,
+			"reason", reason,
+			"step", step,
+			"attempts", attempts,
+			"duration_s", dur.Seconds(),
+			"error", err)
+		return externaldata.Item{
+			Key:   key,
+			Error: "error_fetching_bundle_" + reason,
+		}, ""
+	}
+
+	metrics.AttestationsRetrieved.Add(float64(len(bundles)))
+	slog.Info("validate: fetched OCI bundles",
+		"image", key,
+		"count", len(bundles),
+		"duration_s", dur.Seconds())
+
+	if len(bundles) == 0 {
+		metrics.AttestationsMissing.Inc()
+		slog.Info("validate: no bundles",
+			"image", key)
+		return externaldata.Item{
+			Key:   key,
+			Error: "image_unsigned",
+		}, ""
+	}
+
+	start = time.Now()
+	res, err := p.v.Verify(bundles, hash)
+	dur = time.Since(start)
+	metrics.AttestationsVerTimer.Observe(dur.Seconds())
+	metrics.AttestationsVerOk.Add(float64(len(res)))
+	var fail = len(bundles) - len(res)
+	if fail > 0 {
+		metrics.AttestationsVerFail.Add(float64(fail))
+	}
+
+	if err != nil {
+		slog.Error("validate: verification error",
+			"image", key,
+			"image_digest", hash.Hex,
+			"error", err)
+		return externaldata.Item{}, fmt.Sprintf("ERROR: VerifyImageSignatures(%q): %v", key, err)
+	}
+
+	if len(res) > 0 {
+		slog.Info("validate: found valid signatures",
+			"count", len(res),
+			"image", key)
+		return externaldata.Item{
+			Key:   key,
+			Value: res,
+		}, ""
+	}
+
+	slog.Info("validate: no valid signatures",
+		"image", key)
+	return externaldata.Item{
+		Key:   key,
+		Error: "invalid_signature",
+	}, ""
 }
 
 // ErrorResponse prepare a proper error response per the documentation

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -2,8 +2,12 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/github/artifact-attestations-opa-provider/pkg/verifier"
 	"github.com/stretchr/testify/assert"
@@ -237,4 +241,200 @@ func TestInvalid(t *testing.T) {
 		assert.Len(t, response.Response.Items, 1)
 		assert.Equal(t, tc.error, response.Response.Items[0].Error)
 	}
+}
+
+// erroringVerifier always fails verification, used to exercise the
+// request-level system error path.
+type erroringVerifier struct{}
+
+func (*erroringVerifier) Verify(_ []*bundle.Bundle, _ *v1.Hash) ([]*verify.VerificationResult, error) {
+	return nil, errors.New("verification blew up")
+}
+
+// barrierBundleFetcher rendezvouses the first `width` concurrent fetches at a
+// gate before letting any of them proceed. If the outer per-image loop runs
+// serially, fewer than `width` fetches ever arrive, the gate never opens and
+// the call blocks -- letting a test deterministically distinguish serial from
+// parallel execution without relying on timing. It also records the peak
+// number of simultaneous in-flight fetches.
+type barrierBundleFetcher struct {
+	mockBundleFetcher
+
+	width int
+
+	mu          sync.Mutex
+	inFlight    int
+	maxInFlight int
+	arrived     int
+	gateClosed  bool
+	gate        chan struct{}
+}
+
+func newBarrierBundleFetcher(width int) *barrierBundleFetcher {
+	return &barrierBundleFetcher{width: width, gate: make(chan struct{})}
+}
+
+func (b *barrierBundleFetcher) BundleFromName(ctx context.Context, ref name.Reference, opts []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+	b.mu.Lock()
+	b.inFlight++
+	if b.inFlight > b.maxInFlight {
+		b.maxInFlight = b.inFlight
+	}
+	b.arrived++
+	if b.arrived >= b.width && !b.gateClosed {
+		b.gateClosed = true
+		close(b.gate)
+	}
+	b.mu.Unlock()
+
+	// Block until at least `width` fetches have arrived concurrently.
+	<-b.gate
+
+	res, h, err := b.mockBundleFetcher.BundleFromName(ctx, ref, opts)
+
+	b.mu.Lock()
+	b.inFlight--
+	b.mu.Unlock()
+
+	return res, h, err
+}
+
+func (b *barrierBundleFetcher) MaxInFlight() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.maxInFlight
+}
+
+// validateWithTimeout runs Validate on a goroutine and fails the test if it
+// does not return within d, converting a barrier deadlock (serial execution)
+// into a clear failure instead of a hung test binary.
+func validateWithTimeout(t *testing.T, p *Provider, req *externaldata.ProviderRequest, d time.Duration) *externaldata.ProviderResponse {
+	t.Helper()
+	ch := make(chan *externaldata.ProviderResponse, 1)
+	go func() {
+		ch <- p.Validate(context.Background(), req)
+	}()
+	select {
+	case resp := <-ch:
+		return resp
+	case <-time.After(d):
+		t.Fatal("Validate did not complete in time; images were not processed concurrently")
+		return nil
+	}
+}
+
+func TestWithConcurrency(t *testing.T) {
+	v := &mockVerifier{}
+	kc := &mockKeyChainProvider{}
+	bf := &mockBundleFetcher{}
+
+	// Default is serial.
+	assert.Equal(t, 1, New(v, kc, bf).concurrency)
+	assert.Equal(t, 4, New(v, kc, bf, WithConcurrency(4)).concurrency)
+	// Values below 1 are clamped back to serial.
+	assert.Equal(t, 1, New(v, kc, bf, WithConcurrency(0)).concurrency)
+	assert.Equal(t, 1, New(v, kc, bf, WithConcurrency(-3)).concurrency)
+}
+
+// TestValidateConcurrentMatchesSerial ensures parallel per-image validation
+// produces the same ordered results as the serial default.
+func TestValidateConcurrentMatchesSerial(t *testing.T) {
+	kc := &mockKeyChainProvider{}
+	bf := &mockBundleFetcher{}
+	v := &mockVerifier{}
+
+	req := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{validImageName, "ghcr.io/example/unsigned", brokenImageName, "foo+bar"},
+		},
+	}
+
+	serial := New(v, kc, bf).Validate(context.Background(), req)
+	concurrent := New(v, kc, bf, WithConcurrency(4)).Validate(context.Background(), req)
+
+	require.Len(t, serial.Response.Items, 4)
+	require.Len(t, concurrent.Response.Items, len(serial.Response.Items))
+	assert.Empty(t, serial.Response.SystemError)
+	assert.Empty(t, concurrent.Response.SystemError)
+
+	for i := range serial.Response.Items {
+		assert.Equal(t, serial.Response.Items[i].Key, concurrent.Response.Items[i].Key)
+		assert.Equal(t, serial.Response.Items[i].Error, concurrent.Response.Items[i].Error)
+	}
+
+	// Ordering is preserved and each key maps to its expected outcome.
+	assert.Equal(t, validImageName, concurrent.Response.Items[0].Key)
+	assert.Equal(t, "invalid_signature", concurrent.Response.Items[0].Error)
+	assert.Equal(t, "image_unsigned", concurrent.Response.Items[1].Error)
+	assert.Equal(t, "error_fetching_bundle_unknown", concurrent.Response.Items[2].Error)
+	assert.Equal(t, "invalid_reference", concurrent.Response.Items[3].Error)
+}
+
+// TestValidateProcessesImagesConcurrently proves the outer per-image loop runs
+// in parallel: all images must reach the fetcher's barrier simultaneously.
+func TestValidateProcessesImagesConcurrently(t *testing.T) {
+	const n = 4
+	bf := newBarrierBundleFetcher(n)
+	p := New(&mockVerifier{}, &mockKeyChainProvider{}, bf, WithConcurrency(n))
+
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("ghcr.io/example/image-%d", i)
+	}
+	req := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: keys},
+	}
+
+	resp := validateWithTimeout(t, p, req, 5*time.Second)
+	require.NotNil(t, resp)
+	assert.Len(t, resp.Response.Items, n)
+	assert.Equal(t, n, bf.MaxInFlight())
+}
+
+// TestValidateBoundsConcurrency verifies the worker pool never exceeds the
+// configured limit even when the request has more images than the limit.
+func TestValidateBoundsConcurrency(t *testing.T) {
+	const limit = 2
+	const keys = 4
+	bf := newBarrierBundleFetcher(limit)
+	p := New(&mockVerifier{}, &mockKeyChainProvider{}, bf, WithConcurrency(limit))
+
+	imageKeys := make([]string, keys)
+	for i := range imageKeys {
+		imageKeys[i] = fmt.Sprintf("ghcr.io/example/image-%d", i)
+	}
+	req := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: imageKeys},
+	}
+
+	resp := validateWithTimeout(t, p, req, 5*time.Second)
+	require.NotNil(t, resp)
+	assert.Len(t, resp.Response.Items, keys)
+	// The pool reaches, but never exceeds, the configured limit.
+	assert.Equal(t, limit, bf.MaxInFlight())
+}
+
+// TestValidateConcurrentSystemError ensures a verification error still yields a
+// request-level system error response when images are processed in parallel.
+func TestValidateConcurrentSystemError(t *testing.T) {
+	p := New(&erroringVerifier{}, &mockKeyChainProvider{}, &mockBundleFetcher{}, WithConcurrency(4))
+
+	req := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{validImageName, validImageName},
+		},
+	}
+
+	resp := p.Validate(context.Background(), req)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Response.SystemError)
+	assert.Empty(t, resp.Response.Items)
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -344,6 +344,12 @@ func TestWithConcurrency(t *testing.T) {
 	// Values below 1 are clamped back to serial.
 	assert.Equal(t, 1, New(v, kc, bf, WithConcurrency(0)).concurrency)
 	assert.Equal(t, 1, New(v, kc, bf, WithConcurrency(-3)).concurrency)
+
+	// A single Option is read-only and safe to reuse across providers:
+	// applying it repeatedly yields the same normalized value.
+	opt := WithConcurrency(0)
+	assert.Equal(t, 1, New(v, kc, bf, opt).concurrency)
+	assert.Equal(t, 1, New(v, kc, bf, opt).concurrency)
 }
 
 // TestValidateConcurrentMatchesSerial ensures parallel per-image validation

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -251,6 +251,16 @@ func (*erroringVerifier) Verify(_ []*bundle.Bundle, _ *v1.Hash) ([]*verify.Verif
 	return nil, errors.New("verification blew up")
 }
 
+// panickingBundleFetcher panics on every fetch, used to exercise the
+// concurrent worker's panic-recovery path.
+type panickingBundleFetcher struct {
+	mockBundleFetcher
+}
+
+func (*panickingBundleFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+	panic("boom from fetcher")
+}
+
 // barrierBundleFetcher rendezvouses the first `width` concurrent fetches at a
 // gate before letting any of them proceed. If the outer per-image loop runs
 // serially, fewer than `width` fetches ever arrive, the gate never opens and
@@ -434,6 +444,27 @@ func TestValidateConcurrentSystemError(t *testing.T) {
 	}
 
 	resp := p.Validate(context.Background(), req)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Response.SystemError)
+	assert.Empty(t, resp.Response.Items)
+}
+
+// TestValidateConcurrentRecoversPanic ensures a panic from the fetcher or
+// verifier in a worker goroutine is recovered and surfaced as a system error
+// instead of crashing the whole provider process. Without recovery this test
+// would terminate the test binary.
+func TestValidateConcurrentRecoversPanic(t *testing.T) {
+	p := New(&mockVerifier{}, &mockKeyChainProvider{}, &panickingBundleFetcher{}, WithConcurrency(4))
+
+	req := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{"ghcr.io/example/a", "ghcr.io/example/b", "ghcr.io/example/c"},
+		},
+	}
+
+	resp := validateWithTimeout(t, p, req, 5*time.Second)
 	require.NotNil(t, resp)
 	assert.NotEmpty(t, resp.Response.SystemError)
 	assert.Empty(t, resp.Response.Items)


### PR DESCRIPTION
## Summary

Implements the first idea from #195: verify the images in a multi-image admission request **concurrently** instead of one at a time.

Today `Validate` loops over `r.Request.Keys` and calls `BundleFromName` for each image on the shared request context, so a slow fetch for one image can consume most of the shared deadline and starve the images processed after it. This PR adds an **opt-in, bounded worker pool** for the outer, per-image loop so total wall-clock time approaches the *max* of the per-image fetches rather than the *sum*.

Per the request, scope is deliberately narrow:

- ✅ Parallelize the **outer, per-image** loop only.
- ❌ Do **not** parallelize attestation-bundle retrieval within a single image — each image still fetches its bundles serially (`DoBundleFromName` is untouched).
- ✅ Gated behind a start-up flag that **defaults to the existing serial behavior**.

## Changes

- **`-image-concurrency` flag** (`cmd/aaop/aaop.go`), default `1` (serial). Values `> 1` cap the number of images verified simultaneously; values `< 1` are rejected at start-up.
- **`provider.WithConcurrency(n)` option** (`pkg/provider/provider.go`). `New` is now variadic and defaults to serial; `n < 1` is clamped to `1`.
- Extracted the per-image body into a `validateImage` helper. `Validate` dispatches to a serial path (unchanged, byte-for-byte behavior including the verification-error short-circuit) or a bounded worker pool (`sync.WaitGroup.Go` + a semaphore channel).
- **Ordering and semantics preserved:** response items keep request/key order, and a verification error still yields a request-level `SystemError` (the first error in key order wins, so results are deterministic in either mode).

## Behavior notes

- Default (`-image-concurrency=1`) is identical to the previous serial implementation.
- The shared request context is intentionally unchanged — this PR does not touch `--bundle-timeout` / `--bundle-max-attempts` semantics or introduce per-image sub-budgets (ideas #2–#4 in the issue remain open).
- Prometheus metrics and `slog` calls are goroutine-safe, so per-image metrics/logging are unchanged under parallelism.

## Testing

- `go test -race ./...` passes.
- `golangci-lint run` reports 0 issues.
- New provider tests: serial/parallel result parity, a **deterministic** barrier-based test proving images are processed concurrently (a serial impl would deadlock and fail), a bounded-concurrency test asserting the pool never exceeds the limit, `WithConcurrency` clamping, and the system-error path under concurrency.

## Follow-ups / not included

- The flag is not wired into the Helm chart, consistent with the existing `bundle-*` tuning flags (also chart-less). Happy to add chart plumbing if desired.

Refs #195

> Opened as a **draft** for early feedback on the approach (flag shape, default concurrency bound).