### PR TITLE
Classify 404 (MANIFEST_UNKNOWN) as non-recoverable `not_found`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -49,6 +49,10 @@ const (
 	KindForbidden FailureKind = "forbidden"
 	// KindThrottled indicates the registry returned HTTP 429 (rate limited).
 	KindThrottled FailureKind = "throttled"
+	// KindNotFound indicates the registry returned HTTP 404 (manifest/blob
+	// not found). It is deterministic within a single admission request, so
+	// it is treated as non-recoverable.
+	KindNotFound FailureKind = "not_found"
 	// KindReferrersUnavailable indicates the OCI Referrers API call failed.
 	KindReferrersUnavailable FailureKind = "referrers_unavailable"
 	// KindDescriptorError indicates the image manifest (descriptor) GET failed.
@@ -267,7 +271,8 @@ func newFetchError(step Step, fallback FailureKind, err error) *FetchError {
 	}
 	recoverable := kind != KindUnauthorized &&
 		kind != KindForbidden &&
-		kind != KindBundleInvalid
+		kind != KindBundleInvalid &&
+		kind != KindNotFound
 	return &FetchError{
 		Step:        step,
 		Kind:        kind,
@@ -309,6 +314,8 @@ func classifyTransport(err error) (FailureKind, int) {
 			return KindUnauthorized, transportErr.StatusCode
 		case http.StatusForbidden:
 			return KindForbidden, transportErr.StatusCode
+		case http.StatusNotFound:
+			return KindNotFound, transportErr.StatusCode
 		case http.StatusTooManyRequests:
 			return KindThrottled, transportErr.StatusCode
 		}

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -105,6 +105,12 @@ func TestClassifyTransport(t *testing.T) {
 			wantCode: http.StatusTooManyRequests,
 		},
 		{
+			name:     "not found status",
+			err:      &transport.Error{StatusCode: http.StatusNotFound},
+			wantKind: KindNotFound,
+			wantCode: http.StatusNotFound,
+		},
+		{
 			name: "unauthorized diagnostic",
 			err: &transport.Error{Errors: []transport.Diagnostic{
 				{Code: transport.UnauthorizedErrorCode},
@@ -199,6 +205,13 @@ func TestNewFetchErrorClassifiesAuthAsNonRecoverable(t *testing.T) {
 	assert.True(t, fe.Recoverable)
 }
 
+func TestNewFetchErrorClassifiesNotFoundAsNonRecoverable(t *testing.T) {
+	fe := newFetchError(StepDescriptor, KindDescriptorError, &transport.Error{StatusCode: http.StatusNotFound})
+	assert.Equal(t, KindNotFound, fe.Kind, "404 should classify as not_found, not the descriptor fallback")
+	assert.False(t, fe.Recoverable, "404 is deterministic in-request and should not be retried")
+	assert.Equal(t, http.StatusNotFound, fe.StatusCode)
+}
+
 func TestNewFetchErrorClassifiesThrottling(t *testing.T) {
 	// HTTP 429 status-code branch.
 	fe := newFetchError(StepReferrers, KindReferrersUnavailable, &transport.Error{StatusCode: http.StatusTooManyRequests})
@@ -254,5 +267,21 @@ func TestRetryBundleStopsOnNonRecoverableFetchError(t *testing.T) {
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindUnauthorized, fe.Kind)
 	assert.Equal(t, 1, attempts)
+	assert.Equal(t, 1, fe.Attempts)
+}
+
+func TestRetryBundleStopsOnNotFound(t *testing.T) {
+	var attempts int
+
+	_, _, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		attempts++
+		return nil, nil, newDescriptorError(&transport.Error{StatusCode: http.StatusNotFound})
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindNotFound, fe.Kind)
+	assert.Equal(t, http.StatusNotFound, fe.StatusCode)
+	assert.Equal(t, 1, attempts, "a 404 must not be retried")
 	assert.Equal(t, 1, fe.Attempts)
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -2,9 +2,13 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/github/artifact-attestations-opa-provider/pkg/fetcher"
+	"github.com/github/artifact-attestations-opa-provider/pkg/metrics"
 	"github.com/github/artifact-attestations-opa-provider/pkg/verifier"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +19,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 )
@@ -237,4 +242,47 @@ func TestInvalid(t *testing.T) {
 		assert.Len(t, response.Response.Items, 1)
 		assert.Equal(t, tc.error, response.Response.Items[0].Error)
 	}
+}
+
+// notFoundBundleFetcher always fails with a 404 (MANIFEST_UNKNOWN) fetch
+// error, used to exercise the non-recoverable not_found path.
+type notFoundBundleFetcher struct {
+	mockBundleFetcher
+}
+
+func (*notFoundBundleFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+	return nil, nil, &fetcher.FetchError{
+		Step:        fetcher.StepDescriptor,
+		Kind:        fetcher.KindNotFound,
+		Attempts:    1,
+		StatusCode:  http.StatusNotFound,
+		Recoverable: false,
+		Err:         errors.New("MANIFEST_UNKNOWN"),
+	}
+}
+
+func TestVerifyNotFound(t *testing.T) {
+	v := &mockVerifier{}
+	kc := &mockKeyChainProvider{}
+	bf := &notFoundBundleFetcher{}
+	provider := New(v, kc, bf)
+
+	before := testutil.ToFloat64(metrics.AttestationsRetrieveFail.WithLabelValues("not_found"))
+
+	request := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{validImageName},
+		},
+	}
+
+	response := provider.Validate(context.Background(), request)
+	require.NotNil(t, response)
+	assert.Len(t, response.Response.Items, 1)
+	assert.Equal(t, "error_fetching_bundle_not_found", response.Response.Items[0].Error)
+	assert.Empty(t, response.Response.SystemError)
+
+	after := testutil.ToFloat64(metrics.AttestationsRetrieveFail.WithLabelValues("not_found"))
+	assert.InDelta(t, 1.0, after-before, 0.0001, `fail metric should be labeled reason="not_found"`)
 }


### PR DESCRIPTION
## Summary

When the registry returns **HTTP 404 (`MANIFEST_UNKNOWN`)** for the image manifest, the provider currently retries the fetch the full `--bundle-max-attempts` times (default 3). A 404 is deterministic within the lifetime of a single admission request, so these retries never succeed — they just add extra registry round-trips per failed validation, precisely during rollout bursts when not-yet-pushed images are most common and registry load is already high.

This classifies `404 Not Found` as a **non-recoverable** failure so the retry loop stops after a single attempt, and gives it a distinct `not_found` reason for logs and metrics (previously conflated with `descriptor_error`).

Closes #197

## Changes

`pkg/fetcher/bundle.go`:
- Add `KindNotFound FailureKind = "not_found"`.
- Map `http.StatusNotFound` → `KindNotFound` in `classifyTransport` (applies uniformly to the descriptor, referrers, and blob steps, since all route through `newFetchError`).
- Add `KindNotFound` to the non-recoverable set in `newFetchError`.

## Why not retrying is safe

Marking a 404 non-recoverable only stops the provider's **in-request** retry loop. It does not change the outcome (validation still fails — the manifest genuinely isn't present) and does not affect recovery of a legitimately-racing push, which happens at the **orchestrator admission layer** (a fresh admission request seconds later), not inside the provider's sub-second in-request retries.

**Net effect:** fewer wasted registry round-trips, identical admission behavior. 401/403/429/timeout/cancellation behavior is unchanged.

## Testing

- `pkg/fetcher/bundle_test.go` — 404 classifies as `KindNotFound` (code 404), is non-recoverable, and `retryBundle` makes **exactly one** attempt.
- `pkg/provider/provider_test.go` — item error surfaces as `error_fetching_bundle_not_found` and the fail metric is labeled `reason="not_found"`.
- `scripts/integration_test.sh` — already sums `aaop_attestations_retrieved_fail` across all `reason` series, so it tolerates the new label with no change.
- `go test ./...`, `go vet ./...` (only pre-existing `verifier_test.go` warnings), and `golangci-lint run` all pass.

> Note: adds one indirect dep (`github.com/kylelemons/godebug`) via `go mod tidy`, pulled in by `prometheus/.../testutil` used for the metric-label assertion.

## Acceptance criteria

- [x] A 404 manifest fetch makes a single attempt (`attempts == 1`), not `--bundle-max-attempts`.
- [x] The failure is reported with a distinct `not_found` reason in both logs and the fail metric.
- [x] 401/403/429/timeout/cancellation behavior is unchanged.