### PR TITLE
Bound each registry HTTP request with an overall deadline

### DIFF
--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -50,6 +50,8 @@ var (
 	registryTLSHandshakeTimeout   = flag.Duration("registry-tls-handshake-timeout", 0, "override TLS handshake timeout to the registry; 0 derives it from bundle-timeout")
 	registryResponseHeaderTimeout = flag.Duration("registry-response-header-timeout", 0, "override wait for the registry's response headers; 0 derives it from bundle-timeout")
 
+	registryRequestTimeout = flag.Duration("registry-request-timeout", 0, "overall wall for a single registry HTTP request incl. body; 0 derives it from bundle-timeout")
+
 	updateCABundle = flag.Bool("update-ca-bundle", false, "regularly update the Provider's caBundle field")
 )
 
@@ -74,8 +76,12 @@ func main() {
 	var err error
 
 	flag.Parse()
-	if err := configureBundleFetcher(*bundleMaxAttempts, *bundleTimeout, *bundleDelay,
-		*registryDialTimeout, *registryTLSHandshakeTimeout, *registryResponseHeaderTimeout); err != nil {
+	if err := configureBundleFetcher(*bundleMaxAttempts, *bundleTimeout, *bundleDelay, registryTimeouts{
+		dial:           *registryDialTimeout,
+		tlsHandshake:   *registryTLSHandshakeTimeout,
+		responseHeader: *registryResponseHeaderTimeout,
+		request:        *registryRequestTimeout,
+	}); err != nil {
 		log.Fatal(err)
 	}
 
@@ -193,8 +199,19 @@ func main() {
 	slog.Info("server shut down gracefully")
 }
 
-func configureBundleFetcher(maxAttempts int, timeout, delay time.Duration,
-	dialTimeout, tlsHandshakeTimeout, responseHeaderTimeout time.Duration) error {
+// registryTimeouts groups the optional registry HTTP transport timeout
+// overrides passed to configureBundleFetcher. Every field is "0 = derive from
+// bundle-timeout / use default"; only negative values are rejected. They are
+// grouped into a struct so new transport knobs can be added without pushing
+// configureBundleFetcher past the argument-count limit enforced by the linter.
+type registryTimeouts struct {
+	dial           time.Duration
+	tlsHandshake   time.Duration
+	responseHeader time.Duration
+	request        time.Duration
+}
+
+func configureBundleFetcher(maxAttempts int, timeout, delay time.Duration, rt registryTimeouts) error {
 	if maxAttempts < 1 {
 		return errors.New("bundle-max-attempts must be greater than zero")
 	}
@@ -204,9 +221,9 @@ func configureBundleFetcher(maxAttempts int, timeout, delay time.Duration,
 	if delay < 0 {
 		return errors.New("bundle-delay must not be negative")
 	}
-	// The registry connection-phase timeouts are overrides: 0 means "derive
-	// from bundle-timeout". Only negative values are rejected. An override may
-	// exceed bundle-timeout — consistent with the derived 250ms floor, we let an
+	// The registry transport timeouts are overrides: 0 means "derive from
+	// bundle-timeout". Only negative values are rejected. An override may exceed
+	// bundle-timeout — consistent with the derived 250ms floor, we let an
 	// operator keep a usable connection-setup timeout even when it is larger
 	// than the per-attempt budget (the attempt context simply fires first).
 	// Setting a per-attempt budget that small is treated as operator error, not
@@ -215,9 +232,10 @@ func configureBundleFetcher(maxAttempts int, timeout, delay time.Duration,
 		name  string
 		value time.Duration
 	}{
-		{"registry-dial-timeout", dialTimeout},
-		{"registry-tls-handshake-timeout", tlsHandshakeTimeout},
-		{"registry-response-header-timeout", responseHeaderTimeout},
+		{"registry-dial-timeout", rt.dial},
+		{"registry-tls-handshake-timeout", rt.tlsHandshake},
+		{"registry-response-header-timeout", rt.responseHeader},
+		{"registry-request-timeout", rt.request},
 	} {
 		if o.value < 0 {
 			return fmt.Errorf("%s must not be negative", o.name)
@@ -227,9 +245,10 @@ func configureBundleFetcher(maxAttempts int, timeout, delay time.Duration,
 	fetcher.MaxAttempts = maxAttempts
 	fetcher.Timeout = timeout
 	fetcher.Delay = delay
-	fetcher.DialTimeoutOverride = dialTimeout
-	fetcher.TLSHandshakeTimeoutOverride = tlsHandshakeTimeout
-	fetcher.ResponseHeaderTimeoutOverride = responseHeaderTimeout
+	fetcher.DialTimeoutOverride = rt.dial
+	fetcher.TLSHandshakeTimeoutOverride = rt.tlsHandshake
+	fetcher.ResponseHeaderTimeoutOverride = rt.responseHeader
+	fetcher.RequestTimeoutOverride = rt.request
 	// Rebuild the shared registry transport now that Timeout and the overrides
 	// are set, so its connection-phase timeouts track the per-attempt budget.
 	fetcher.ConfigureTransport()

--- a/cmd/aaop/aaop_test.go
+++ b/cmd/aaop/aaop_test.go
@@ -9,25 +9,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigureBundleFetcher(t *testing.T) {
-	originalMaxAttempts := fetcher.MaxAttempts
-	originalTimeout := fetcher.Timeout
-	originalDelay := fetcher.Delay
-	originalDial := fetcher.DialTimeoutOverride
-	originalTLS := fetcher.TLSHandshakeTimeoutOverride
-	originalResponseHeader := fetcher.ResponseHeaderTimeoutOverride
+// restoreFetcherConfig snapshots every fetcher tunable configureBundleFetcher
+// mutates and restores it (plus the shared transport) after the test, so cases
+// that set overrides do not leak into later tests.
+func restoreFetcherConfig(t *testing.T) {
+	t.Helper()
+
+	maxAttempts := fetcher.MaxAttempts
+	timeout := fetcher.Timeout
+	delay := fetcher.Delay
+	dial := fetcher.DialTimeoutOverride
+	tlsHandshake := fetcher.TLSHandshakeTimeoutOverride
+	responseHeader := fetcher.ResponseHeaderTimeoutOverride
+	request := fetcher.RequestTimeoutOverride
 	t.Cleanup(func() {
-		fetcher.MaxAttempts = originalMaxAttempts
-		fetcher.Timeout = originalTimeout
-		fetcher.Delay = originalDelay
-		fetcher.DialTimeoutOverride = originalDial
-		fetcher.TLSHandshakeTimeoutOverride = originalTLS
-		fetcher.ResponseHeaderTimeoutOverride = originalResponseHeader
+		fetcher.MaxAttempts = maxAttempts
+		fetcher.Timeout = timeout
+		fetcher.Delay = delay
+		fetcher.DialTimeoutOverride = dial
+		fetcher.TLSHandshakeTimeoutOverride = tlsHandshake
+		fetcher.ResponseHeaderTimeoutOverride = responseHeader
+		fetcher.RequestTimeoutOverride = request
 		fetcher.ConfigureTransport()
 	})
+}
 
-	// Zero overrides: phase timeouts are derived from bundle-timeout.
-	err := configureBundleFetcher(5, 750*time.Millisecond, 25*time.Millisecond, 0, 0, 0)
+func TestConfigureBundleFetcher(t *testing.T) {
+	restoreFetcherConfig(t)
+
+	// Zero overrides: connection-phase timeouts derive from bundle-timeout and
+	// the overall request wall is derived too.
+	err := configureBundleFetcher(5, 750*time.Millisecond, 25*time.Millisecond, registryTimeouts{})
 
 	require.NoError(t, err)
 	assert.Equal(t, 5, fetcher.MaxAttempts)
@@ -36,63 +48,48 @@ func TestConfigureBundleFetcher(t *testing.T) {
 	assert.Zero(t, fetcher.DialTimeoutOverride)
 	assert.Zero(t, fetcher.TLSHandshakeTimeoutOverride)
 	assert.Zero(t, fetcher.ResponseHeaderTimeoutOverride)
+	assert.Zero(t, fetcher.RequestTimeoutOverride)
 }
 
 func TestConfigureBundleFetcherHonorsTransportOverrides(t *testing.T) {
-	originalTimeout := fetcher.Timeout
-	originalDial := fetcher.DialTimeoutOverride
-	originalTLS := fetcher.TLSHandshakeTimeoutOverride
-	originalResponseHeader := fetcher.ResponseHeaderTimeoutOverride
-	t.Cleanup(func() {
-		fetcher.Timeout = originalTimeout
-		fetcher.DialTimeoutOverride = originalDial
-		fetcher.TLSHandshakeTimeoutOverride = originalTLS
-		fetcher.ResponseHeaderTimeoutOverride = originalResponseHeader
-		fetcher.ConfigureTransport()
-	})
+	restoreFetcherConfig(t)
 
-	err := configureBundleFetcher(3, 5*time.Second, 0,
-		1*time.Second, 2*time.Second, 3*time.Second)
+	err := configureBundleFetcher(3, 5*time.Second, 0, registryTimeouts{
+		dial:           1 * time.Second,
+		tlsHandshake:   2 * time.Second,
+		responseHeader: 3 * time.Second,
+		request:        8 * time.Second,
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, 1*time.Second, fetcher.DialTimeoutOverride)
 	assert.Equal(t, 2*time.Second, fetcher.TLSHandshakeTimeoutOverride)
 	assert.Equal(t, 3*time.Second, fetcher.ResponseHeaderTimeoutOverride)
+	assert.Equal(t, 8*time.Second, fetcher.RequestTimeoutOverride)
 }
 
 func TestConfigureBundleFetcherAllowsOverrideAboveBudget(t *testing.T) {
-	originalTimeout := fetcher.Timeout
-	originalDial := fetcher.DialTimeoutOverride
-	originalTLS := fetcher.TLSHandshakeTimeoutOverride
-	originalResponseHeader := fetcher.ResponseHeaderTimeoutOverride
-	t.Cleanup(func() {
-		fetcher.Timeout = originalTimeout
-		fetcher.DialTimeoutOverride = originalDial
-		fetcher.TLSHandshakeTimeoutOverride = originalTLS
-		fetcher.ResponseHeaderTimeoutOverride = originalResponseHeader
-		fetcher.ConfigureTransport()
-	})
+	restoreFetcherConfig(t)
 
 	// An override larger than bundle-timeout is accepted: like the derived
 	// 250ms floor, an operator may keep a usable connection-setup timeout even
 	// when it exceeds the per-attempt budget. Only negative values are rejected.
-	err := configureBundleFetcher(3, 1*time.Second, 0,
-		5*time.Second, 0, 0)
+	err := configureBundleFetcher(3, 1*time.Second, 0, registryTimeouts{dial: 5 * time.Second})
 
 	require.NoError(t, err)
 	assert.Equal(t, 5*time.Second, fetcher.DialTimeoutOverride)
 }
 
 func TestConfigureBundleFetcherRejectsInvalidValues(t *testing.T) {
+	restoreFetcherConfig(t)
+
 	tests := []struct {
-		name                  string
-		maxAttempts           int
-		timeout               time.Duration
-		delay                 time.Duration
-		dialTimeout           time.Duration
-		tlsHandshakeTimeout   time.Duration
-		responseHeaderTimeout time.Duration
-		errorText             string
+		name        string
+		maxAttempts int
+		timeout     time.Duration
+		delay       time.Duration
+		timeouts    registryTimeouts
+		errorText   string
 	}{
 		{
 			name:        "zero attempts",
@@ -123,8 +120,15 @@ func TestConfigureBundleFetcherRejectsInvalidValues(t *testing.T) {
 			name:        "negative dial timeout",
 			maxAttempts: 1,
 			timeout:     time.Second,
-			dialTimeout: -time.Millisecond,
+			timeouts:    registryTimeouts{dial: -time.Millisecond},
 			errorText:   "registry-dial-timeout must not be negative",
+		},
+		{
+			name:        "negative request timeout",
+			maxAttempts: 1,
+			timeout:     time.Second,
+			timeouts:    registryTimeouts{request: -time.Millisecond},
+			errorText:   "registry-request-timeout must not be negative",
 		},
 	}
 
@@ -134,8 +138,7 @@ func TestConfigureBundleFetcherRejectsInvalidValues(t *testing.T) {
 			fetcher.Timeout = 9 * time.Second
 			fetcher.Delay = 9 * time.Millisecond
 
-			err := configureBundleFetcher(test.maxAttempts, test.timeout, test.delay,
-				test.dialTimeout, test.tlsHandshakeTimeout, test.responseHeaderTimeout)
+			err := configureBundleFetcher(test.maxAttempts, test.timeout, test.delay, test.timeouts)
 
 			require.EqualError(t, err, test.errorText)
 			assert.Equal(t, 9, fetcher.MaxAttempts)

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -45,6 +46,14 @@ var (
 	// verbatim. The overrides let an operator with an unusual registry or
 	// forward proxy tune a single phase without restating the whole budget.
 	ResponseHeaderTimeoutOverride = time.Duration(0)
+
+	// RequestTimeoutOverride optionally pins the overall wall for a single
+	// registry HTTP request, covering connect, headers, and body. Zero derives
+	// it from Timeout (see resolveRequestTimeout); a positive value is used
+	// verbatim. It is a backstop that bounds any request phase the per-phase
+	// timeouts miss — most importantly a response body-read stall, which
+	// ResponseHeaderTimeout (header-only) does not cover.
+	RequestTimeoutOverride = time.Duration(0)
 )
 
 // Registry connection-phase timeouts are a decomposition of the per-attempt
@@ -145,6 +154,68 @@ func newRegistryTransport() *http.Transport {
 	t.TLSHandshakeTimeout = tlsHandshake
 	t.ResponseHeaderTimeout = responseHeader
 	return t
+}
+
+// resolveRequestTimeout returns the overall per-request wall: RequestTimeoutOverride
+// when positive, otherwise the per-attempt budget (Timeout). Bounding each HTTP
+// request by the per-attempt budget is a safe ceiling — it will not fire before
+// the attempt context under normal operation.
+func resolveRequestTimeout() time.Duration {
+	if RequestTimeoutOverride > 0 {
+		return RequestTimeoutOverride
+	}
+
+	return Timeout
+}
+
+// deadlineRoundTripper bounds each registry HTTP request — including body reads —
+// by an overall wall, the same mechanism http.Client.Timeout uses internally.
+// go-containerregistry (v0.21.9) exposes only remote.WithTransport, with no
+// http.Client hook, so the wall must be a RoundTripper decorator. It wraps the
+// shared *http.Transport, so the connection-phase timeouts still apply beneath
+// it. The base transport and timeout are captured when GetRemoteOptions builds
+// the wrapper, so a transport rebuilt by ConfigureTransport and a retuned budget
+// are picked up the next time the options are constructed.
+type deadlineRoundTripper struct {
+	base    http.RoundTripper
+	timeout time.Duration
+}
+
+func (d deadlineRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if d.timeout <= 0 {
+		return d.base.RoundTrip(req)
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), d.timeout)
+
+	resp, err := d.base.RoundTrip(req.WithContext(ctx))
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	// Keep the deadline armed through body reading; releasing it here would let
+	// a slow body stall unbounded. cancelOnCloseBody releases it exactly once
+	// when the caller closes the body.
+	resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancel}
+
+	return resp, nil
+}
+
+// cancelOnCloseBody wraps a response body so the request's context cancel func
+// is invoked exactly once when the body is closed, releasing the deadline set by
+// deadlineRoundTripper after the body has been fully read.
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.once.Do(b.cancel)
+
+	return err
 }
 
 // FailureKind is a stable, low-cardinality classification of why a bundle
@@ -510,7 +581,11 @@ func GetRemoteOptions(kc authn.Keychain) []remote.Option {
 	var opts = []remote.Option{
 		remote.WithUserAgent(UserAgentString),
 		remote.WithAuthFromKeychain(kc),
-		remote.WithTransport(registryTransport),
+		// Wrap the shared transport in the overall per-request wall. The base
+		// stays the *http.Transport singleton so ConfigureTransport rebuilds and
+		// re-tunes its connection-phase timeouts; the wrapper is rebuilt here on
+		// each call with the current request timeout.
+		remote.WithTransport(deadlineRoundTripper{base: registryTransport, timeout: resolveRequestTimeout()}),
 	}
 
 	return opts

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -422,4 +424,137 @@ func restoreTransportOverrides(dial, tlsHandshake, responseHeader time.Duration)
 	DialTimeoutOverride = dial
 	TLSHandshakeTimeoutOverride = tlsHandshake
 	ResponseHeaderTimeoutOverride = responseHeader
+}
+
+// roundTripFunc adapts a function to http.RoundTripper so deadlineRoundTripper
+// can be driven with a scripted base transport.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+// blockingBody blocks on Read until its context is done, then returns the
+// context error. It simulates a response body that stalls mid-read so tests can
+// prove the overall request wall covers body reads, not just the header wait.
+type blockingBody struct {
+	ctx context.Context
+}
+
+func (b blockingBody) Read([]byte) (int, error) {
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (blockingBody) Close() error {
+	return nil
+}
+
+func newTestRequest(t *testing.T) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.test", http.NoBody)
+	require.NoError(t, err)
+
+	return req
+}
+
+func TestDeadlineRoundTripperTimesOutBeforeResponse(t *testing.T) {
+	rt := deadlineRoundTripper{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}),
+		timeout: 20 * time.Millisecond,
+	}
+
+	start := time.Now()
+	resp, err := rt.RoundTrip(newTestRequest(t))
+	elapsed := time.Since(start)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 2*time.Second, "RoundTrip must abort at ~timeout, not hang")
+}
+
+func TestDeadlineRoundTripperBoundsBodyRead(t *testing.T) {
+	rt := deadlineRoundTripper{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			// Headers return immediately; the body then stalls. Only a wall that
+			// covers the body (not just the header wait) can break this.
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       blockingBody{ctx: req.Context()},
+			}, nil
+		}),
+		timeout: 20 * time.Millisecond,
+	}
+
+	resp, err := rt.RoundTrip(newTestRequest(t))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	_, readErr := io.ReadAll(resp.Body)
+	require.ErrorIs(t, readErr, context.DeadlineExceeded, "the deadline must fire during the body read")
+}
+
+func TestDeadlineRoundTripperPassesThroughAndCancelsOnClose(t *testing.T) {
+	var capturedCtx context.Context
+
+	rt := deadlineRoundTripper{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			capturedCtx = req.Context()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("hello")),
+			}, nil
+		}),
+		timeout: time.Minute,
+	}
+
+	resp, err := rt.RoundTrip(newTestRequest(t))
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(body))
+	require.NoError(t, capturedCtx.Err(), "the deadline must stay armed while the body is read")
+
+	closeErr := resp.Body.Close()
+	require.NoError(t, closeErr)
+	assert.ErrorIs(t, capturedCtx.Err(), context.Canceled, "closing the body must release the deadline")
+}
+
+func TestDeadlineRoundTripperDisabledPassesResponseUnwrapped(t *testing.T) {
+	want := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}
+	rt := deadlineRoundTripper{
+		base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return want, nil
+		}),
+		timeout: 0,
+	}
+
+	resp, err := rt.RoundTrip(newTestRequest(t))
+
+	require.NoError(t, err)
+	assert.Same(t, want, resp, "a non-positive timeout must be a pure passthrough")
+	_, wrapped := resp.Body.(*cancelOnCloseBody)
+	assert.False(t, wrapped, "the body must not be wrapped when the wall is disabled")
+	resp.Body.Close()
+}
+
+func TestResolveRequestTimeout(t *testing.T) {
+	origOverride, origTimeout := RequestTimeoutOverride, Timeout
+	t.Cleanup(func() {
+		RequestTimeoutOverride, Timeout = origOverride, origTimeout
+	})
+
+	Timeout = 4 * time.Second
+	RequestTimeoutOverride = 0
+	assert.Equal(t, 4*time.Second, resolveRequestTimeout(), "zero override derives from Timeout")
+
+	RequestTimeoutOverride = 9 * time.Second
+	assert.Equal(t, 9*time.Second, resolveRequestTimeout(), "positive override used verbatim")
 }


### PR DESCRIPTION
## Summary

Adds an overall per-request wall to the shared registry HTTP transport, closing a gap left by the connection-establishment timeouts in #206. 

#206's timeouts (dial, TLS handshake, response header) only govern setting up a brand-new connection, and `ResponseHeaderTimeout` stops once headers arrive. None of them bound a stall during the response **body** read on an already-established connection. So a wedged reused keep-alive connection could hang a manifest/referrers/blob fetch past the retry envelope all the way to the outer admission deadline — the incident signature: `reason=canceled`, `step=descriptor`, `status=0`, idle CPU, no network error logged.

## Change

`deadlineRoundTripper` (`pkg/fetcher/bundle.go`) — a `RoundTripper` decorator that wraps each registry request in `context.WithTimeout` and wraps `resp.Body` so the deadline also covers body reads (the same mechanism `http.Client.Timeout` uses internally). go-containerregistry v0.21.9 exposes only `remote.WithTransport` — no `http.Client` hook — so the wall must be a decorator. It's applied in `GetRemoteOptions` over the shared `*http.Transport`, so #206's connection-phase timeouts still apply beneath it, and it protects **every** caller of that transport. `cancelOnCloseBody` releases the deadline exactly once on `Body.Close()`.

- New flag **`-registry-request-timeout`** (default `0` = derive from `-bundle-timeout`, a safe ceiling that won't fire before the per-attempt context). Only negatives are rejected.
- The registry timeout overrides are grouped into a `registryTimeouts` struct so `configureBundleFetcher` stays within revive's argument-count limit (6).



## Test plan

- `pkg/fetcher/bundle_test.go`: `deadlineRoundTripper` — header stall, **body-read stall**, passthrough + cancel-on-close (no leak), and `timeout<=0` pure passthrough; `resolveRequestTimeout` (derive vs override).
- `cmd/aaop/aaop_test.go`: `configureBundleFetcher` wires `-registry-request-timeout` and rejects it when negative.

Local: `go build ./...`, `go test ./... -race`, `go vet ./pkg/fetcher/... ./cmd/aaop/...` (clean), `golangci-lint run ./...` → **0 issues**.

## Rollout

Default is safe (`0` derives from `-bundle-timeout`), so no deployment flag change is required. Complementary to #206.
