### PR TITLE
Tune registry connection pool to self-heal dead connections

### DIFF
--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -50,6 +50,11 @@ var (
 	registryTLSHandshakeTimeout   = flag.Duration("registry-tls-handshake-timeout", 0, "override TLS handshake timeout to the registry; 0 derives it from bundle-timeout")
 	registryResponseHeaderTimeout = flag.Duration("registry-response-header-timeout", 0, "override wait for the registry's response headers; 0 derives it from bundle-timeout")
 
+	registryDialKeepAlive       = flag.Duration("registry-dial-keep-alive", 10*time.Second, "TCP keep-alive period for registry connections, keeping pooled connections warm; 0 uses the net/http default")
+	registryIdleConnTimeout     = flag.Duration("registry-idle-conn-timeout", 10*time.Second, "how long an idle registry connection is kept in the pool before being closed; 0 means no limit")
+	registryMaxIdleConns        = flag.Int("registry-max-idle-conns", 25, "max idle registry connections retained across all hosts; 0 means unlimited")
+	registryMaxIdleConnsPerHost = flag.Int("registry-max-idle-conns-per-host", 25, "max idle registry connections retained per host; 0 uses the net/http default of 2")
+
 	updateCABundle = flag.Bool("update-ca-bundle", false, "regularly update the Provider's caBundle field")
 )
 
@@ -74,6 +79,10 @@ func main() {
 	var err error
 
 	flag.Parse()
+	if err := configureRegistryPool(*registryDialKeepAlive, *registryIdleConnTimeout,
+		*registryMaxIdleConns, *registryMaxIdleConnsPerHost); err != nil {
+		log.Fatal(err)
+	}
 	if err := configureBundleFetcher(*bundleMaxAttempts, *bundleTimeout, *bundleDelay,
 		*registryDialTimeout, *registryTLSHandshakeTimeout, *registryResponseHeaderTimeout); err != nil {
 		log.Fatal(err)
@@ -233,6 +242,43 @@ func configureBundleFetcher(maxAttempts int, timeout, delay time.Duration,
 	// Rebuild the shared registry transport now that Timeout and the overrides
 	// are set, so its connection-phase timeouts track the per-attempt budget.
 	fetcher.ConfigureTransport()
+	return nil
+}
+
+// configureRegistryPool validates the registry connection-pool tuning flags and
+// applies them to the fetcher package vars. It deliberately does not rebuild the
+// shared transport itself: call it before configureBundleFetcher, whose
+// ConfigureTransport() applies these values and the fetch-budget timeouts in a
+// single rebuild. Zero is accepted for every value (net/http reads it as "no
+// limit" / "use default"); only negative values are rejected.
+func configureRegistryPool(dialKeepAlive, idleConnTimeout time.Duration, maxIdleConns, maxIdleConnsPerHost int) error {
+	for _, d := range []struct {
+		name  string
+		value time.Duration
+	}{
+		{"registry-dial-keep-alive", dialKeepAlive},
+		{"registry-idle-conn-timeout", idleConnTimeout},
+	} {
+		if d.value < 0 {
+			return fmt.Errorf("%s must not be negative", d.name)
+		}
+	}
+	for _, c := range []struct {
+		name  string
+		value int
+	}{
+		{"registry-max-idle-conns", maxIdleConns},
+		{"registry-max-idle-conns-per-host", maxIdleConnsPerHost},
+	} {
+		if c.value < 0 {
+			return fmt.Errorf("%s must not be negative", c.name)
+		}
+	}
+
+	fetcher.DialKeepAlive = dialKeepAlive
+	fetcher.IdleConnTimeout = idleConnTimeout
+	fetcher.MaxIdleConns = maxIdleConns
+	fetcher.MaxIdleConnsPerHost = maxIdleConnsPerHost
 	return nil
 }
 

--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -50,7 +50,7 @@ var (
 	registryTLSHandshakeTimeout   = flag.Duration("registry-tls-handshake-timeout", 0, "override TLS handshake timeout to the registry; 0 derives it from bundle-timeout")
 	registryResponseHeaderTimeout = flag.Duration("registry-response-header-timeout", 0, "override wait for the registry's response headers; 0 derives it from bundle-timeout")
 
-	registryDialKeepAlive       = flag.Duration("registry-dial-keep-alive", 10*time.Second, "TCP keep-alive period for registry connections, keeping pooled connections warm; 0 uses the net/http default")
+	registryDialKeepAlive       = flag.Duration("registry-dial-keep-alive", 10*time.Second, "TCP keep-alive period for registry connections, keeping pooled connections warm; 0 uses Go's default keep-alive period (~15s)")
 	registryIdleConnTimeout     = flag.Duration("registry-idle-conn-timeout", 10*time.Second, "how long an idle registry connection is kept in the pool before being closed; 0 means no limit")
 	registryMaxIdleConns        = flag.Int("registry-max-idle-conns", 25, "max idle registry connections retained across all hosts; 0 means unlimited")
 	registryMaxIdleConnsPerHost = flag.Int("registry-max-idle-conns-per-host", 25, "max idle registry connections retained per host; 0 uses the net/http default of 2")
@@ -249,8 +249,13 @@ func configureBundleFetcher(maxAttempts int, timeout, delay time.Duration,
 // applies them to the fetcher package vars. It deliberately does not rebuild the
 // shared transport itself: call it before configureBundleFetcher, whose
 // ConfigureTransport() applies these values and the fetch-budget timeouts in a
-// single rebuild. Zero is accepted for every value (net/http reads it as "no
-// limit" / "use default"); only negative values are rejected.
+// single rebuild.
+//
+// Zero is accepted for every value; only negatives are rejected. Zero's meaning
+// differs by field: dialKeepAlive is a net.Dialer.KeepAlive (not an
+// http.Transport field), so 0 selects Go's default keep-alive period (~15s);
+// idleConnTimeout=0 and maxIdleConns=0 mean "no limit"; maxIdleConnsPerHost=0
+// selects net/http's default of 2.
 func configureRegistryPool(dialKeepAlive, idleConnTimeout time.Duration, maxIdleConns, maxIdleConnsPerHost int) error {
 	for _, d := range []struct {
 		name  string

--- a/cmd/aaop/aaop_test.go
+++ b/cmd/aaop/aaop_test.go
@@ -144,3 +144,89 @@ func TestConfigureBundleFetcherRejectsInvalidValues(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigureRegistryPool(t *testing.T) {
+	originalKeepAlive := fetcher.DialKeepAlive
+	originalIdle := fetcher.IdleConnTimeout
+	originalMaxIdle := fetcher.MaxIdleConns
+	originalMaxIdlePerHost := fetcher.MaxIdleConnsPerHost
+	t.Cleanup(func() {
+		fetcher.DialKeepAlive = originalKeepAlive
+		fetcher.IdleConnTimeout = originalIdle
+		fetcher.MaxIdleConns = originalMaxIdle
+		fetcher.MaxIdleConnsPerHost = originalMaxIdlePerHost
+		fetcher.ConfigureTransport()
+	})
+
+	err := configureRegistryPool(15*time.Second, 20*time.Second, 30, 12)
+
+	require.NoError(t, err)
+	assert.Equal(t, 15*time.Second, fetcher.DialKeepAlive)
+	assert.Equal(t, 20*time.Second, fetcher.IdleConnTimeout)
+	assert.Equal(t, 30, fetcher.MaxIdleConns)
+	assert.Equal(t, 12, fetcher.MaxIdleConnsPerHost)
+}
+
+func TestConfigureRegistryPoolAllowsZero(t *testing.T) {
+	originalKeepAlive := fetcher.DialKeepAlive
+	originalIdle := fetcher.IdleConnTimeout
+	originalMaxIdle := fetcher.MaxIdleConns
+	originalMaxIdlePerHost := fetcher.MaxIdleConnsPerHost
+	t.Cleanup(func() {
+		fetcher.DialKeepAlive = originalKeepAlive
+		fetcher.IdleConnTimeout = originalIdle
+		fetcher.MaxIdleConns = originalMaxIdle
+		fetcher.MaxIdleConnsPerHost = originalMaxIdlePerHost
+		fetcher.ConfigureTransport()
+	})
+
+	// Zero is a valid net/http choice (no limit / use default), so it is
+	// accepted verbatim rather than rejected or coerced to the defaults.
+	err := configureRegistryPool(0, 0, 0, 0)
+
+	require.NoError(t, err)
+	assert.Zero(t, fetcher.DialKeepAlive)
+	assert.Zero(t, fetcher.IdleConnTimeout)
+	assert.Zero(t, fetcher.MaxIdleConns)
+	assert.Zero(t, fetcher.MaxIdleConnsPerHost)
+}
+
+func TestConfigureRegistryPoolRejectsNegative(t *testing.T) {
+	tests := []struct {
+		name                string
+		dialKeepAlive       time.Duration
+		idleConnTimeout     time.Duration
+		maxIdleConns        int
+		maxIdleConnsPerHost int
+		errorText           string
+	}{
+		{
+			name:          "negative dial keep-alive",
+			dialKeepAlive: -time.Millisecond,
+			errorText:     "registry-dial-keep-alive must not be negative",
+		},
+		{
+			name:            "negative idle conn timeout",
+			idleConnTimeout: -time.Millisecond,
+			errorText:       "registry-idle-conn-timeout must not be negative",
+		},
+		{
+			name:         "negative max idle conns",
+			maxIdleConns: -1,
+			errorText:    "registry-max-idle-conns must not be negative",
+		},
+		{
+			name:                "negative max idle conns per host",
+			maxIdleConnsPerHost: -1,
+			errorText:           "registry-max-idle-conns-per-host must not be negative",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := configureRegistryPool(test.dialKeepAlive, test.idleConnTimeout,
+				test.maxIdleConns, test.maxIdleConnsPerHost)
+			require.EqualError(t, err, test.errorText)
+		})
+	}
+}

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -59,7 +59,9 @@ var (
 	// DialKeepAlive is the TCP keep-alive period for registry connections. A
 	// shorter period keeps a pooled connection warm so an idle network
 	// intermediary (e.g. an Azure Load Balancer with a ~4-minute idle cutoff)
-	// is less likely to silently reap it.
+	// is less likely to silently reap it. It is a net.Dialer.KeepAlive, so zero
+	// selects Go's default period (~15s); a negative value would disable
+	// keep-alives (configureRegistryPool rejects negatives).
 	DialKeepAlive = 10 * time.Second
 	// IdleConnTimeout is how long a connection may sit idle in the pool before
 	// it is closed. Well below common intermediary idle cutoffs, so a

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -45,6 +45,37 @@ var (
 	// verbatim. The overrides let an operator with an unusual registry or
 	// forward proxy tune a single phase without restating the whole budget.
 	ResponseHeaderTimeoutOverride = time.Duration(0)
+
+	// Connection-pool tuning. Unlike the per-phase timeouts above, these are
+	// direct values (not derived from Timeout): they govern the lifetime and
+	// size of the pooled keep-alive connections, which is a function of the
+	// registry/network topology, not the per-attempt fetch budget. They exist
+	// because the connection-establishment timeouts only bound a *new*
+	// connection — a connection that a load balancer or gateway silently drops
+	// while idle in the pool is invisible to them and stalls the next request
+	// that reuses it. Shorter lifetimes evict such a connection before it is
+	// reused; a smaller pool caps how many dead connections can accumulate.
+
+	// DialKeepAlive is the TCP keep-alive period for registry connections. A
+	// shorter period keeps a pooled connection warm so an idle network
+	// intermediary (e.g. an Azure Load Balancer with a ~4-minute idle cutoff)
+	// is less likely to silently reap it.
+	DialKeepAlive = 10 * time.Second
+	// IdleConnTimeout is how long a connection may sit idle in the pool before
+	// it is closed. Well below common intermediary idle cutoffs, so a
+	// silently-dropped idle connection is retired by us rather than lingering to
+	// stall a future request. Zero means no limit (net/http semantics).
+	IdleConnTimeout = 10 * time.Second
+	// MaxIdleConns caps idle connections retained across all hosts. Sized from
+	// measured peak in-flight fetches per pod (single digits) doubled for the
+	// two hosts a fetch touches — the registry and the blob backend it
+	// 307-redirects to — so the reuse working set is covered with headroom while
+	// capping dead-connection accumulation far below go-containerregistry's
+	// inherited 100. Zero means unlimited (net/http semantics).
+	MaxIdleConns = 25
+	// MaxIdleConnsPerHost caps idle connections retained per host. Zero selects
+	// net/http's default of 2, so it is set explicitly alongside MaxIdleConns.
+	MaxIdleConnsPerHost = 25
 )
 
 // Registry connection-phase timeouts are a decomposition of the per-attempt
@@ -129,21 +160,25 @@ func pickPhaseTimeout(override, bundleTimeout time.Duration, fraction float64) t
 func newRegistryDialer(timeout time.Duration) *net.Dialer {
 	return &net.Dialer{
 		Timeout:   timeout,
-		KeepAlive: 30 * time.Second,
+		KeepAlive: DialKeepAlive,
 	}
 }
 
 // newRegistryTransport returns an http.Transport based on go-containerregistry's
 // DefaultTransport but with the connection-establishment timeouts resolved from
-// the current per-attempt budget (see resolveTransportTimeouts). Cloning the
-// default preserves the other tuned fields (idle-connection pool sizes, HTTP/2,
-// proxy) while overriding only the timeouts.
+// the current per-attempt budget (see resolveTransportTimeouts) and the idle
+// connection-pool lifetime/size tuned for self-healing (see DialKeepAlive,
+// IdleConnTimeout, MaxIdleConns). Cloning the default preserves the remaining
+// fields (HTTP/2, proxy) while overriding only what we tune.
 func newRegistryTransport() *http.Transport {
 	dial, tlsHandshake, responseHeader := resolveTransportTimeouts(Timeout)
 	t := remote.DefaultTransport.(*http.Transport).Clone()
 	t.DialContext = newRegistryDialer(dial).DialContext
 	t.TLSHandshakeTimeout = tlsHandshake
 	t.ResponseHeaderTimeout = responseHeader
+	t.IdleConnTimeout = IdleConnTimeout
+	t.MaxIdleConns = MaxIdleConns
+	t.MaxIdleConnsPerHost = MaxIdleConnsPerHost
 	return t
 }
 

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -382,14 +382,13 @@ func TestNewRegistryTransportUsesResolvedTimeouts(t *testing.T) {
 	assert.Equal(t, wantTLS, tr.TLSHandshakeTimeout)
 	assert.Equal(t, wantResponseHeader, tr.ResponseHeaderTimeout)
 
-	// The transport must carry the tuned idle-pool lifetime and sizes, which
-	// override go-containerregistry's inherited defaults (90s / 100 / 50).
+	// The transport must carry the tuned idle-pool lifetime and sizes (the
+	// package-var defaults), overriding go-containerregistry's inherited
+	// 90s / 100 / 50. Wiring of non-default values is covered separately by
+	// TestNewRegistryTransportAppliesPoolTuning.
 	assert.Equal(t, 10*time.Second, tr.IdleConnTimeout)
 	assert.Equal(t, 25, tr.MaxIdleConns)
 	assert.Equal(t, 25, tr.MaxIdleConnsPerHost)
-	assert.Equal(t, IdleConnTimeout, tr.IdleConnTimeout, "transport must wire the IdleConnTimeout package var")
-	assert.Equal(t, MaxIdleConns, tr.MaxIdleConns, "transport must wire the MaxIdleConns package var")
-	assert.Equal(t, MaxIdleConnsPerHost, tr.MaxIdleConnsPerHost, "transport must wire the MaxIdleConnsPerHost package var")
 
 	// Cloning the default transport must preserve its remaining tuning rather
 	// than resetting to the net/http zero values.

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -348,7 +348,7 @@ func TestNewRegistryDialerUsesResolvedTimeout(t *testing.T) {
 	// are caught).
 	d := newRegistryDialer(1234 * time.Millisecond)
 	assert.Equal(t, 1234*time.Millisecond, d.Timeout)
-	assert.Equal(t, 30*time.Second, d.KeepAlive)
+	assert.Equal(t, DialKeepAlive, d.KeepAlive, "dialer must carry the configured keep-alive, not a hardcoded value")
 }
 
 func TestRegistryTransportDialContextEnforcesDialTimeout(t *testing.T) {
@@ -382,12 +382,36 @@ func TestNewRegistryTransportUsesResolvedTimeouts(t *testing.T) {
 	assert.Equal(t, wantTLS, tr.TLSHandshakeTimeout)
 	assert.Equal(t, wantResponseHeader, tr.ResponseHeaderTimeout)
 
-	// Cloning the default transport must preserve its connection-pool tuning
-	// rather than resetting to the net/http zero values.
-	assert.Equal(t, 100, tr.MaxIdleConns)
-	assert.Equal(t, 50, tr.MaxIdleConnsPerHost)
+	// The transport must carry the tuned idle-pool lifetime and sizes, which
+	// override go-containerregistry's inherited defaults (90s / 100 / 50).
+	assert.Equal(t, 10*time.Second, tr.IdleConnTimeout)
+	assert.Equal(t, 25, tr.MaxIdleConns)
+	assert.Equal(t, 25, tr.MaxIdleConnsPerHost)
+	assert.Equal(t, IdleConnTimeout, tr.IdleConnTimeout, "transport must wire the IdleConnTimeout package var")
+	assert.Equal(t, MaxIdleConns, tr.MaxIdleConns, "transport must wire the MaxIdleConns package var")
+	assert.Equal(t, MaxIdleConnsPerHost, tr.MaxIdleConnsPerHost, "transport must wire the MaxIdleConnsPerHost package var")
+
+	// Cloning the default transport must preserve its remaining tuning rather
+	// than resetting to the net/http zero values.
 	assert.True(t, tr.ForceAttemptHTTP2)
 	require.NotNil(t, tr.DialContext)
+}
+
+func TestNewRegistryTransportAppliesPoolTuning(t *testing.T) {
+	// Non-default values must flow through to the transport, proving the pool
+	// fields are wired from the package vars rather than hardcoded.
+	origIdle, origMax, origMaxPer := IdleConnTimeout, MaxIdleConns, MaxIdleConnsPerHost
+	t.Cleanup(func() {
+		IdleConnTimeout, MaxIdleConns, MaxIdleConnsPerHost = origIdle, origMax, origMaxPer
+	})
+	IdleConnTimeout = 11 * time.Second
+	MaxIdleConns = 13
+	MaxIdleConnsPerHost = 9
+
+	tr := newRegistryTransport()
+	assert.Equal(t, 11*time.Second, tr.IdleConnTimeout)
+	assert.Equal(t, 13, tr.MaxIdleConns)
+	assert.Equal(t, 9, tr.MaxIdleConnsPerHost)
 }
 
 func TestConfigureTransportRebuildsForCurrentTimeout(t *testing.T) {


### PR DESCRIPTION
## Summary

Tightens three connection-pool knobs on the shared registry transport so a keep-alive connection that a network intermediary silently dropped is retired before it can stall a future request. This is the root-cause complement to #206 (fail-fast on connection *establishment*) .

The connection-establishment timeouts in #206 only bound setting up a **new** connection. A connection that a load balancer or gateway drops while it sits **idle in the pool** is invisible to them — the next request that reuses it stalls until the outer admission deadline (the class-H "reused connection stall": idle pods, `status=0`, no network error in the logs).

## Changes

| Knob | Was (inherited from go-containerregistry) | Now | Why |
|---|---|---|---|
| dialer `KeepAlive` | 30s | **10s** | Keep pooled connections warm so an idle intermediary (e.g. an Azure Load Balancer with a ~4-min idle cutoff) is less likely to silently reap them. |
| `IdleConnTimeout` | 90s | **10s** | Close an idle connection well before those cutoffs, so a silently-dropped one is retired by us instead of lingering to stall the next request. |
| `MaxIdleConns` / `MaxIdleConnsPerHost` | 100 / 50 | **25 / 25** | Cap dead-connection accumulation. |

Exposed as `fetcher` package vars with safe defaults + optional override flags (`-registry-dial-keep-alive`, `-registry-idle-conn-timeout`, `-registry-max-idle-conns`, `-registry-max-idle-conns-per-host`), validated and applied in a new `configureRegistryPool` helper before the transport is built. Zero keeps net/http semantics (no limit / use default); only negatives are rejected.

