### PR TITLE
Fail fast on registry throttling (HTTP 429)

### DIFF
--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -32,19 +32,20 @@ import (
 )
 
 var (
-	noPGI             = flag.Bool("no-public-good", false, "disable public good sigstore instance")
-	certsDir          = flag.String("certs", "", "Directory to where TLS certs are stored")
-	trustDomains      = flag.String("trust-domain", "", "comma separated trust domains to use")
-	tufRepo           = flag.String("tuf-repo", "", "URL to TUF repository")
-	tufRoot           = flag.String("tuf-root", "", "Path to a root.json used to initialize TUF repository")
-	tufTargets        = flag.String("tuf-targets", "", "Comma separated list of targets to load as trust roots")
-	ns                = flag.String("namespace", "", "namespace the pod runs in")
-	ips               = flag.String("image-pull-secret", "", "the imagePullSecret to use for private registries")
-	port              = flag.String("port", "8080", "port to listen to")
-	metricsPort       = flag.String("metrics-port", "9090", "port to listen to for metrics")
-	bundleMaxAttempts = flag.Int("bundle-max-attempts", 3, "max attempts to fetch a bundle")
-	bundleTimeout     = flag.Duration("bundle-timeout", 3*time.Second, "timeout for a single attempt to fetch a bundle")
-	bundleDelay       = flag.Duration("bundle-delay", 0, "delay between attempts to fetch a bundle")
+	noPGI                = flag.Bool("no-public-good", false, "disable public good sigstore instance")
+	certsDir             = flag.String("certs", "", "Directory to where TLS certs are stored")
+	trustDomains         = flag.String("trust-domain", "", "comma separated trust domains to use")
+	tufRepo              = flag.String("tuf-repo", "", "URL to TUF repository")
+	tufRoot              = flag.String("tuf-root", "", "Path to a root.json used to initialize TUF repository")
+	tufTargets           = flag.String("tuf-targets", "", "Comma separated list of targets to load as trust roots")
+	ns                   = flag.String("namespace", "", "namespace the pod runs in")
+	ips                  = flag.String("image-pull-secret", "", "the imagePullSecret to use for private registries")
+	port                 = flag.String("port", "8080", "port to listen to")
+	metricsPort          = flag.String("metrics-port", "9090", "port to listen to for metrics")
+	bundleMaxAttempts    = flag.Int("bundle-max-attempts", 3, "max attempts to fetch a bundle")
+	bundleTimeout        = flag.Duration("bundle-timeout", 3*time.Second, "timeout for a single attempt to fetch a bundle")
+	bundleDelay          = flag.Duration("bundle-delay", 0, "delay between attempts to fetch a bundle")
+	bundleRetryThrottled = flag.Bool("bundle-retry-throttled", false, "retry registry throttling (HTTP 429) in-line instead of failing fast")
 
 	registryDialTimeout           = flag.Duration("registry-dial-timeout", 0, "override TCP dial timeout to the registry; 0 derives it from bundle-timeout")
 	registryTLSHandshakeTimeout   = flag.Duration("registry-tls-handshake-timeout", 0, "override TLS handshake timeout to the registry; 0 derives it from bundle-timeout")
@@ -87,6 +88,7 @@ func main() {
 		*registryDialTimeout, *registryTLSHandshakeTimeout, *registryResponseHeaderTimeout); err != nil {
 		log.Fatal(err)
 	}
+	fetcher.RetryThrottled = *bundleRetryThrottled
 
 	var vCfg = app.VerifierCfg{
 		TufRoot: *tufRoot,

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -32,6 +32,14 @@ var (
 	Timeout = time.Second * 3
 	// Delay between attempts to fetch bundles.
 	Delay = time.Duration(0)
+	// RetryThrottled controls whether registry throttling (HTTP 429) is retried
+	// in-line. It is false by default: within the provider's short per-request
+	// budget an in-line retry cannot outlast an aggregate, per-identity
+	// rate-limit window and only adds load while the registry is shedding it, so
+	// a 429 fails fast. Operators whose registry uses a different rate-limit
+	// model (e.g. a refilling token bucket) can set this true to restore the
+	// previous retry behavior.
+	RetryThrottled = false
 
 	// DialTimeoutOverride optionally pins the registry TCP dial timeout. Zero
 	// (the default) derives it from Timeout via resolveTransportTimeouts; a
@@ -415,10 +423,10 @@ func DoBundleFromName(ctx context.Context, ref name.Reference, ro []remote.Optio
 // failure Kind (and HTTP status, when available) from the underlying error,
 // falling back to the supplied kind for unclassified errors. Authentication
 // failures and invalid bundles are marked non-recoverable so retries stop.
-// Throttling (HTTP 429) is also marked non-recoverable: an in-line retry within
-// our per-request budget cannot outlast the registry's aggregate, per-identity
-// rate-limit window, and retrying only adds load while the registry is shedding
-// it.
+// Throttling (HTTP 429) is non-recoverable unless RetryThrottled is set: within
+// the provider's short per-request budget an in-line retry cannot outlast the
+// registry's aggregate, per-identity rate-limit window and only adds load while
+// the registry is shedding it.
 func newFetchError(step Step, fallback FailureKind, err error) *FetchError {
 	kind, code := classifyTransport(err)
 	if kind == KindUnknown {
@@ -428,7 +436,7 @@ func newFetchError(step Step, fallback FailureKind, err error) *FetchError {
 		kind != KindForbidden &&
 		kind != KindBundleInvalid &&
 		kind != KindNotFound &&
-		kind != KindThrottled
+		(RetryThrottled || kind != KindThrottled)
 	return &FetchError{
 		Step:        step,
 		Kind:        kind,

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -415,6 +415,10 @@ func DoBundleFromName(ctx context.Context, ref name.Reference, ro []remote.Optio
 // failure Kind (and HTTP status, when available) from the underlying error,
 // falling back to the supplied kind for unclassified errors. Authentication
 // failures and invalid bundles are marked non-recoverable so retries stop.
+// Throttling (HTTP 429) is also marked non-recoverable: an in-line retry within
+// our per-request budget cannot outlast the registry's aggregate, per-identity
+// rate-limit window, and retrying only adds load while the registry is shedding
+// it.
 func newFetchError(step Step, fallback FailureKind, err error) *FetchError {
 	kind, code := classifyTransport(err)
 	if kind == KindUnknown {
@@ -423,7 +427,8 @@ func newFetchError(step Step, fallback FailureKind, err error) *FetchError {
 	recoverable := kind != KindUnauthorized &&
 		kind != KindForbidden &&
 		kind != KindBundleInvalid &&
-		kind != KindNotFound
+		kind != KindNotFound &&
+		kind != KindThrottled
 	return &FetchError{
 		Step:        step,
 		Kind:        kind,

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -217,14 +217,30 @@ func TestNewFetchErrorClassifiesThrottling(t *testing.T) {
 	fe := newFetchError(StepReferrers, KindReferrersUnavailable, &transport.Error{StatusCode: http.StatusTooManyRequests})
 	assert.Equal(t, KindThrottled, fe.Kind)
 	assert.Equal(t, http.StatusTooManyRequests, fe.StatusCode)
-	assert.True(t, fe.Recoverable, "throttling should be retried")
+	assert.False(t, fe.Recoverable, "429 is not cleared by in-line retry within our budget; fail fast")
 
 	// TooManyRequests diagnostic-code branch (status code not populated).
 	fe = newFetchError(StepDescriptor, KindDescriptorError, &transport.Error{
 		Errors: []transport.Diagnostic{{Code: transport.TooManyRequestsErrorCode}},
 	})
 	assert.Equal(t, KindThrottled, fe.Kind)
-	assert.True(t, fe.Recoverable, "throttling should be retried")
+	assert.False(t, fe.Recoverable, "429 is not cleared by in-line retry within our budget; fail fast")
+}
+
+func TestRetryBundleFailsFastOnThrottle(t *testing.T) {
+	var attempts int
+
+	_, _, err := retryBundle(t.Context(), 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		attempts++
+		return nil, nil, newBlobError(&transport.Error{StatusCode: http.StatusTooManyRequests})
+	})
+
+	assert.Equal(t, 1, attempts, "a 429 must fail fast, not retry in-line")
+
+	var fe *FetchError
+	assert.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindThrottled, fe.Kind)
+	assert.Equal(t, 1, fe.Attempts)
 }
 
 func TestRetryBundlePreservesStepOnCancellation(t *testing.T) {

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -238,7 +238,7 @@ func TestRetryBundleFailsFastOnThrottle(t *testing.T) {
 	assert.Equal(t, 1, attempts, "a 429 must fail fast, not retry in-line")
 
 	var fe *FetchError
-	assert.ErrorAs(t, err, &fe)
+	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindThrottled, fe.Kind)
 	assert.Equal(t, 1, fe.Attempts)
 }

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -243,6 +243,35 @@ func TestRetryBundleFailsFastOnThrottle(t *testing.T) {
 	assert.Equal(t, 1, fe.Attempts)
 }
 
+func TestNewFetchErrorRetriesThrottlingWhenEnabled(t *testing.T) {
+	t.Cleanup(func() { RetryThrottled = false })
+	RetryThrottled = true
+
+	fe := newFetchError(StepReferrers, KindReferrersUnavailable, &transport.Error{StatusCode: http.StatusTooManyRequests})
+	assert.Equal(t, KindThrottled, fe.Kind)
+	assert.True(t, fe.Recoverable, "with -bundle-retry-throttled a 429 is recoverable again")
+}
+
+func TestRetryBundleRetriesThrottleWhenEnabled(t *testing.T) {
+	t.Cleanup(func() { RetryThrottled = false })
+	RetryThrottled = true
+
+	const maxAttempts = 3
+	var attempts int
+
+	_, _, err := retryBundle(t.Context(), maxAttempts, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		attempts++
+		return nil, nil, newBlobError(&transport.Error{StatusCode: http.StatusTooManyRequests})
+	})
+
+	assert.Equal(t, maxAttempts, attempts, "with retry-throttled enabled a 429 retries like other recoverable errors")
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindThrottled, fe.Kind)
+	assert.Equal(t, maxAttempts, fe.Attempts)
+}
+
 func TestRetryBundlePreservesStepOnCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 


### PR DESCRIPTION
## Summary

Classify a registry `429 Too Many Requests` as **non-recoverable** so the fetch retry loop returns immediately (`attempts=1`, `reason=throttled`) instead of spending the request budget on retries that cannot succeed. A new `-bundle-retry-throttled` flag (default `false`) restores the previous in-line retry behavior for operators who want it.

## Why

Registry throttling is typically aggregate, per-identity rate limiting: a 429 clears only when the *combined* request rate against the registry drops below the limit — not on a timer any single client controls. The retry policy is a fixed sub-second delay (`-bundle-delay`) run across a few attempts inside one short per-request budget, so every retry lands in the same rate-limit window and *adds* load during the exact window the registry is shedding it (retry amplification).

A fetch that exhausts its retries on a 429 still ends in a 429, so those retries only burn budget. Validation is sequential per pod, so a hopeless throttle-retry on one image also steals budget from that pod's remaining images. The retry that *can* succeed happens a layer up — the control loop re-creates the pod on a longer, naturally jittered timescale that can outlast a throttle window.

## Configuration

`-bundle-retry-throttled` (default `false`) — when `false`, a 429 fails fast. The provider is registry-agnostic; operators fronting a registry with a different rate-limit model (e.g. a refilling token bucket, where a delayed retry can succeed) can set it `true` to restore in-line 429 retries, subject to the existing `-bundle-max-attempts` / `-bundle-delay` / `-bundle-timeout` knobs.

## The change

`KindThrottled` joins the non-recoverable set in `newFetchError`, gated on `RetryThrottled`. When throttling is non-recoverable, the existing early-return in `retryBundle` fires on the first 429 — returning immediately with `Kind=KindThrottled`, `Attempts=1`, and `StatusCode=429` intact, before any inter-attempt delay or parent-context check. No provider or metrics plumbing changes are needed: the existing `reason=throttled` failure counter and error log become the honest throttle signal.

## Tests

- `TestNewFetchErrorClassifiesThrottling` — a 429 is non-recoverable by default.
- `TestRetryBundleFailsFastOnThrottle` — a 429 returns after exactly one attempt.
- `TestNewFetchErrorRetriesThrottlingWhenEnabled` / `TestRetryBundleRetriesThrottleWhenEnabled` — with `-bundle-retry-throttled`, a 429 is recoverable again and retries to `maxAttempts`.
- Existing retry regressions stay green: per-attempt timeout still retries, success-on-3rd-attempt still works, and a generic connection-reset blob error stays recoverable.

## Validation

```bash
go build ./...
go test ./...
```
