### PR TITLE
Add HTTP connection-phase tracing on bundle fetch failures

### DIFF
--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -57,6 +57,8 @@ var (
 	registryMaxIdleConns        = flag.Int("registry-max-idle-conns", 25, "max idle registry connections retained across all hosts; 0 means unlimited")
 	registryMaxIdleConnsPerHost = flag.Int("registry-max-idle-conns-per-host", 25, "max idle registry connections retained per host; 0 uses the net/http default of 2")
 
+	registryTrace = flag.Bool("registry-trace", true, "emit HTTP connection-phase timings on fetch failures")
+
 	updateCABundle = flag.Bool("update-ca-bundle", false, "regularly update the Provider's caBundle field")
 )
 
@@ -90,6 +92,7 @@ func main() {
 		log.Fatal(err)
 	}
 	fetcher.RetryThrottled = *bundleRetryThrottled
+	fetcher.TraceEnabled = *registryTrace
 
 	var vCfg = app.VerifierCfg{
 		TufRoot: *tufRoot,

--- a/pkg/fetcher/trace.go
+++ b/pkg/fetcher/trace.go
@@ -17,6 +17,12 @@ var TraceEnabled = true
 // durations, which are always non-negative.
 const notRecorded int64 = -1
 
+// durationUnset marks a phase timing that has not been observed. It is negative
+// so Fields can distinguish an unobserved phase (for example, the
+// DNS/connect/TLS phases that are skipped when a pooled connection is reused)
+// from a phase that completed in under a millisecond, which rounds to zero.
+const durationUnset = time.Duration(-1)
+
 // TraceCollector accumulates HTTP connection-phase timings for one bundle
 // fetch. A fetch issues several requests (and retries); the collector keeps
 // per-fetch counts plus the phase timings of the most recently used
@@ -46,10 +52,17 @@ type TraceCollector struct {
 }
 
 // NewTraceCollector returns a TraceCollector ready to instrument one fetch. The
-// time-to-first-byte starts at -1 so a fetch that never receives a response
-// byte is distinguishable from one that received it instantly.
+// phase timings start at the unset sentinel so a phase that never runs (for
+// example, time-to-first-byte on a black-holed connection, or DNS/connect/TLS
+// on a reused one) is distinguishable from one that completed in under a
+// millisecond.
 func NewTraceCollector() *TraceCollector {
-	return &TraceCollector{ttfb: -1}
+	return &TraceCollector{
+		dns:     durationUnset,
+		connect: durationUnset,
+		tls:     durationUnset,
+		ttfb:    durationUnset,
+	}
 }
 
 // Trace returns a ClientTrace whose hooks record connection-phase timings into
@@ -58,12 +71,20 @@ func (c *TraceCollector) Trace() *httptrace.ClientTrace {
 	return &httptrace.ClientTrace{
 		GetConn: func(string) {
 			c.mu.Lock()
-			c.ttfb = -1
+			// Reset every per-request field so a stall in this request is never
+			// described with a prior request's connection state. Unobserved
+			// phases use durationUnset (not zero) so "skipped" stays distinct
+			// from "completed in <1ms"; lastReused and gotConnAt are cleared so
+			// a fresh dial that fails before GotConn is not reported as a reuse
+			// of the previous connection.
+			c.ttfb = durationUnset
+			c.dns = durationUnset
+			c.connect = durationUnset
+			c.tls = durationUnset
 			c.wroteReq = false
-			c.dns = 0
-			c.connect = 0
-			c.tls = 0
+			c.lastReused = false
 			c.lastIdle = 0
+			c.gotConnAt = time.Time{}
 			c.mu.Unlock()
 		},
 		GotConn: func(info httptrace.GotConnInfo) {
@@ -88,6 +109,12 @@ func (c *TraceCollector) Trace() *httptrace.ClientTrace {
 			c.dns = time.Since(c.dnsStart)
 			c.mu.Unlock()
 		},
+		// ConnectStart and ConnectDone assume a single TCP connect attempt is in
+		// flight at a time. Under the platform's default dual-stack Fast
+		// Fallback a host may briefly race IPv4 and IPv6 connects; if that
+		// happens connect_ms reflects the most recent attempt rather than the
+		// exact winning dial. The connection-reuse and time-to-first-byte
+		// signals this instrumentation exists for are unaffected.
 		ConnectStart: func(_, _ string) {
 			c.mu.Lock()
 			c.connStart = time.Now()
@@ -108,7 +135,15 @@ func (c *TraceCollector) Trace() *httptrace.ClientTrace {
 			c.tls = time.Since(c.tlsStart)
 			c.mu.Unlock()
 		},
-		WroteRequest: func(httptrace.WroteRequestInfo) {
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			// WroteRequest also fires when the write itself failed, carrying the
+			// error in info.Err. Recording only the success case keeps
+			// wrote_request=true with ttfb_ms=-1 meaning "request written, no
+			// response" (the black-hole signature) rather than a masked write
+			// failure.
+			if info.Err != nil {
+				return
+			}
 			c.mu.Lock()
 			c.wroteReq = true
 			c.mu.Unlock()

--- a/pkg/fetcher/trace.go
+++ b/pkg/fetcher/trace.go
@@ -159,9 +159,12 @@ func (c *TraceCollector) Trace() *httptrace.ClientTrace {
 }
 
 // Fields returns structured log key/values describing where the fetch spent
-// its connection time. A ttfb_ms of -1 means no response byte was ever
-// received on the last connection: the request was written into a connection
-// that returned nothing before the deadline.
+// its connection time. The black-hole signature — a request written into a
+// connection that returned nothing before the deadline — is the combination
+// wrote_request=true and ttfb_ms=-1. A ttfb_ms of -1 on its own only means no
+// response byte was recorded on the last connection, which is also the case
+// when establishment (DNS/connect/TLS) or the request write failed before any
+// byte could arrive; pair it with wrote_request to tell those apart.
 func (c *TraceCollector) Fields() []any {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/fetcher/trace.go
+++ b/pkg/fetcher/trace.go
@@ -1,0 +1,152 @@
+package fetcher
+
+import (
+	"crypto/tls"
+	"net/http/httptrace"
+	"sync"
+	"time"
+)
+
+// TraceEnabled gates connection instrumentation. Set from a flag at startup
+// (default true). Overhead is a few timestamp captures per request.
+var TraceEnabled = true
+
+// notRecorded is the sentinel returned for a phase timing that was never
+// observed (for example, time-to-first-byte when no response byte ever
+// arrived). It is negative so it is unambiguous alongside real millisecond
+// durations, which are always non-negative.
+const notRecorded int64 = -1
+
+// TraceCollector accumulates HTTP connection-phase timings for one bundle
+// fetch. A fetch issues several requests (and retries); the collector keeps
+// per-fetch counts plus the phase timings of the most recently used
+// connection, which is the one in flight when a stall trips the per-attempt
+// deadline. All fields are guarded by mu because GotFirstResponseByte can fire
+// from the transport's read goroutine.
+type TraceCollector struct {
+	mu sync.Mutex
+
+	reusedConns int
+	newConns    int
+
+	// Most-recent-connection fields, reset per request at GetConn.
+	lastReused bool
+	lastIdle   time.Duration
+	dns        time.Duration
+	connect    time.Duration
+	tls        time.Duration
+	ttfb       time.Duration // GotConn to first response byte; -1 if never.
+	wroteReq   bool
+
+	// Transient phase-start timestamps.
+	dnsStart  time.Time
+	connStart time.Time
+	tlsStart  time.Time
+	gotConnAt time.Time
+}
+
+// NewTraceCollector returns a TraceCollector ready to instrument one fetch. The
+// time-to-first-byte starts at -1 so a fetch that never receives a response
+// byte is distinguishable from one that received it instantly.
+func NewTraceCollector() *TraceCollector {
+	return &TraceCollector{ttfb: -1}
+}
+
+// Trace returns a ClientTrace whose hooks record connection-phase timings into
+// the collector. Attach it to a request context with httptrace.WithClientTrace.
+func (c *TraceCollector) Trace() *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		GetConn: func(string) {
+			c.mu.Lock()
+			c.ttfb = -1
+			c.wroteReq = false
+			c.dns = 0
+			c.connect = 0
+			c.tls = 0
+			c.lastIdle = 0
+			c.mu.Unlock()
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			c.mu.Lock()
+			c.gotConnAt = time.Now()
+			c.lastReused = info.Reused
+			if info.Reused {
+				c.reusedConns++
+				c.lastIdle = info.IdleTime
+			} else {
+				c.newConns++
+			}
+			c.mu.Unlock()
+		},
+		DNSStart: func(httptrace.DNSStartInfo) {
+			c.mu.Lock()
+			c.dnsStart = time.Now()
+			c.mu.Unlock()
+		},
+		DNSDone: func(httptrace.DNSDoneInfo) {
+			c.mu.Lock()
+			c.dns = time.Since(c.dnsStart)
+			c.mu.Unlock()
+		},
+		ConnectStart: func(_, _ string) {
+			c.mu.Lock()
+			c.connStart = time.Now()
+			c.mu.Unlock()
+		},
+		ConnectDone: func(_, _ string, _ error) {
+			c.mu.Lock()
+			c.connect = time.Since(c.connStart)
+			c.mu.Unlock()
+		},
+		TLSHandshakeStart: func() {
+			c.mu.Lock()
+			c.tlsStart = time.Now()
+			c.mu.Unlock()
+		},
+		TLSHandshakeDone: func(tls.ConnectionState, error) {
+			c.mu.Lock()
+			c.tls = time.Since(c.tlsStart)
+			c.mu.Unlock()
+		},
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			c.mu.Lock()
+			c.wroteReq = true
+			c.mu.Unlock()
+		},
+		GotFirstResponseByte: func() {
+			c.mu.Lock()
+			if !c.gotConnAt.IsZero() {
+				c.ttfb = time.Since(c.gotConnAt)
+			}
+			c.mu.Unlock()
+		},
+	}
+}
+
+// Fields returns structured log key/values describing where the fetch spent
+// its connection time. A ttfb_ms of -1 means no response byte was ever
+// received on the last connection: the request was written into a connection
+// that returned nothing before the deadline.
+func (c *TraceCollector) Fields() []any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ms := func(d time.Duration) int64 {
+		if d < 0 {
+			return notRecorded
+		}
+		return d.Milliseconds()
+	}
+
+	return []any{
+		"conns_reused", c.reusedConns,
+		"conns_new", c.newConns,
+		"last_conn_reused", c.lastReused,
+		"last_conn_idle_ms", c.lastIdle.Milliseconds(),
+		"dns_ms", ms(c.dns),
+		"connect_ms", ms(c.connect),
+		"tls_ms", ms(c.tls),
+		"wrote_request", c.wroteReq,
+		"ttfb_ms", ms(c.ttfb),
+	}
+}

--- a/pkg/fetcher/trace_test.go
+++ b/pkg/fetcher/trace_test.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
@@ -12,6 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// errBrokenPipe is a stand-in for a request-write failure surfaced through
+// httptrace.WroteRequestInfo.Err.
+var errBrokenPipe = errors.New("broken pipe")
 
 // fieldMap turns the flat key/value slice returned by Fields into a map so a
 // test can look a field up by name.
@@ -64,6 +69,54 @@ func TestTraceCollectorReusedConnectionNeverReturnsFirstByte(t *testing.T) {
 	assert.Equal(t, int64(8000), asInt64(t, f["last_conn_idle_ms"]))
 	assert.Equal(t, true, f["wrote_request"])
 	assert.Equal(t, int64(-1), asInt64(t, f["ttfb_ms"]))
+	// A reused connection skips DNS/connect/TLS entirely, which must read as
+	// "not observed" (-1) rather than a real zero-duration phase.
+	assert.Equal(t, int64(-1), asInt64(t, f["dns_ms"]))
+	assert.Equal(t, int64(-1), asInt64(t, f["connect_ms"]))
+	assert.Equal(t, int64(-1), asInt64(t, f["tls_ms"]))
+}
+
+// TestTraceCollectorClearsPriorConnectionOnNewRequest verifies that a request
+// which fails during establishment (GetConn but no GotConn) does not inherit
+// the previous request's reuse state, so the failure line cannot claim a
+// connection was reused when the failing dial was fresh.
+func TestTraceCollectorClearsPriorConnectionOnNewRequest(t *testing.T) {
+	c := NewTraceCollector()
+	tr := c.Trace()
+
+	// First request: a reused connection that completes.
+	tr.GetConn("registry.example:443")
+	tr.GotConn(httptrace.GotConnInfo{Reused: true, IdleTime: 5 * time.Second})
+	tr.GotFirstResponseByte()
+
+	// Second request: acquires a connection slot but fails before GotConn
+	// (for example, a fresh dial that never connects).
+	tr.GetConn("registry.example:443")
+
+	f := fieldMap(t, c.Fields())
+	assert.Equal(t, false, f["last_conn_reused"],
+		"stale reuse state from the prior request must be cleared at GetConn")
+	assert.Equal(t, int64(0), asInt64(t, f["last_conn_idle_ms"]))
+	assert.Equal(t, int64(-1), asInt64(t, f["ttfb_ms"]),
+		"a request that never received a byte must not inherit the prior ttfb")
+	// The fetch-level reuse count still reflects the first, completed request.
+	assert.Equal(t, 1, asInt(t, f["conns_reused"]))
+}
+
+// TestTraceCollectorIgnoresFailedRequestWrite verifies that a WroteRequest hook
+// carrying an error does not set wrote_request, so a write failure is not
+// misreported as the black-hole signature (request written, no response).
+func TestTraceCollectorIgnoresFailedRequestWrite(t *testing.T) {
+	c := NewTraceCollector()
+	tr := c.Trace()
+
+	tr.GetConn("registry.example:443")
+	tr.GotConn(httptrace.GotConnInfo{Reused: false})
+	tr.WroteRequest(httptrace.WroteRequestInfo{Err: errBrokenPipe})
+
+	f := fieldMap(t, c.Fields())
+	assert.Equal(t, false, f["wrote_request"],
+		"a failed request write must not be recorded as written")
 }
 
 // TestTraceCollectorFreshDialRecordsPhaseDurations drives the establishment

--- a/pkg/fetcher/trace_test.go
+++ b/pkg/fetcher/trace_test.go
@@ -1,0 +1,167 @@
+package fetcher
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fieldMap turns the flat key/value slice returned by Fields into a map so a
+// test can look a field up by name.
+func fieldMap(t *testing.T, kvs []any) map[string]any {
+	t.Helper()
+	require.Equal(t, 0, len(kvs)%2, "Fields must return an even number of elements")
+
+	m := make(map[string]any, len(kvs)/2)
+	for i := 0; i < len(kvs); i += 2 {
+		key, ok := kvs[i].(string)
+		require.Truef(t, ok, "field key at index %d must be a string, got %T", i, kvs[i])
+		m[key] = kvs[i+1]
+	}
+	return m
+}
+
+// asInt extracts an int field value, failing the test if it is another type.
+func asInt(t *testing.T, v any) int {
+	t.Helper()
+	n, ok := v.(int)
+	require.Truef(t, ok, "expected int, got %T", v)
+	return n
+}
+
+// asInt64 extracts an int64 field value, failing the test if it is another type.
+func asInt64(t *testing.T, v any) int64 {
+	t.Helper()
+	n, ok := v.(int64)
+	require.Truef(t, ok, "expected int64, got %T", v)
+	return n
+}
+
+// TestTraceCollectorReusedConnectionNeverReturnsFirstByte drives the trace
+// hooks directly for the black-hole signature: a reused, long-idle connection
+// that the request is written into but from which no response byte ever
+// arrives.
+func TestTraceCollectorReusedConnectionNeverReturnsFirstByte(t *testing.T) {
+	c := NewTraceCollector()
+	tr := c.Trace()
+
+	tr.GetConn("registry.example:443")
+	tr.GotConn(httptrace.GotConnInfo{Reused: true, IdleTime: 8 * time.Second})
+	tr.WroteRequest(httptrace.WroteRequestInfo{})
+	// Deliberately no GotFirstResponseByte: the connection was black-holed.
+
+	f := fieldMap(t, c.Fields())
+	assert.Equal(t, 1, asInt(t, f["conns_reused"]))
+	assert.Equal(t, 0, asInt(t, f["conns_new"]))
+	assert.Equal(t, true, f["last_conn_reused"])
+	assert.Equal(t, int64(8000), asInt64(t, f["last_conn_idle_ms"]))
+	assert.Equal(t, true, f["wrote_request"])
+	assert.Equal(t, int64(-1), asInt64(t, f["ttfb_ms"]))
+}
+
+// TestTraceCollectorFreshDialRecordsPhaseDurations drives the establishment
+// hooks for a fresh connection and asserts the DNS, connect, and TLS phase
+// durations are recorded.
+func TestTraceCollectorFreshDialRecordsPhaseDurations(t *testing.T) {
+	c := NewTraceCollector()
+	tr := c.Trace()
+
+	// A small sleep between each phase's start and done makes the recorded
+	// duration reliably greater than a millisecond without slowing the test.
+	tr.GetConn("registry.example:443")
+	tr.DNSStart(httptrace.DNSStartInfo{})
+	time.Sleep(2 * time.Millisecond)
+	tr.DNSDone(httptrace.DNSDoneInfo{})
+	tr.ConnectStart("tcp", "10.0.0.1:443")
+	time.Sleep(2 * time.Millisecond)
+	tr.ConnectDone("tcp", "10.0.0.1:443", nil)
+	tr.TLSHandshakeStart()
+	time.Sleep(2 * time.Millisecond)
+	tr.TLSHandshakeDone(tls.ConnectionState{}, nil)
+	tr.GotConn(httptrace.GotConnInfo{Reused: false})
+
+	f := fieldMap(t, c.Fields())
+	assert.Equal(t, 1, asInt(t, f["conns_new"]))
+	assert.Equal(t, 0, asInt(t, f["conns_reused"]))
+	assert.Equal(t, false, f["last_conn_reused"])
+	assert.Positive(t, asInt64(t, f["dns_ms"]))
+	assert.Positive(t, asInt64(t, f["connect_ms"]))
+	assert.Positive(t, asInt64(t, f["tls_ms"]))
+}
+
+// TestTraceCollectorInstrumentsRealRequest confirms the ClientTrace propagates
+// through a real net/http transport when attached to the request context: a
+// successful HTTPS fetch on a fresh connection records the connection counts
+// and a time-to-first-byte.
+func TestTraceCollectorInstrumentsRealRequest(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A brief delay before the first byte guarantees a measurable ttfb.
+		time.Sleep(5 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewTraceCollector()
+	ctx := httptrace.WithClientTrace(t.Context(), c.Trace())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	// The request targets the local httptest server under test, not
+	// attacker-controlled input.
+	// #nosec G704
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	f := fieldMap(t, c.Fields())
+	assert.Equal(t, 1, asInt(t, f["conns_new"]))
+	assert.Equal(t, 0, asInt(t, f["conns_reused"]))
+	assert.Equal(t, false, f["last_conn_reused"])
+	// connect_ms and tls_ms are sub-millisecond on loopback, so only their
+	// presence and non-negativity are asserted here; the synthetic fresh-dial
+	// test above exercises their timing exactly.
+	assert.GreaterOrEqual(t, asInt64(t, f["connect_ms"]), int64(0))
+	assert.GreaterOrEqual(t, asInt64(t, f["tls_ms"]), int64(0))
+	assert.Positive(t, asInt64(t, f["ttfb_ms"]))
+}
+
+// TestTraceCollectorReportsBlackHoleOnRealRequest simulates a black-holed
+// connection with a handler that accepts the request but never writes a
+// response. The request ages out and the collector reports the request was
+// written but no first byte was received.
+func TestTraceCollectorReportsBlackHoleOnRealRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		// Accept the request but never respond; unblock when the client's
+		// context is cancelled so the handler does not leak.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := NewTraceCollector()
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	ctx = httptrace.WithClientTrace(ctx, c.Trace())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	// The request targets the local httptest server under test, not
+	// attacker-controlled input.
+	// #nosec G704
+	resp, err := srv.Client().Do(req)
+	require.Error(t, err)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	f := fieldMap(t, c.Fields())
+	assert.Equal(t, true, f["wrote_request"])
+	assert.Equal(t, int64(-1), asInt64(t, f["ttfb_ms"]))
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http/httptrace"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -124,7 +125,17 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		}
 
 		start := time.Now()
-		bundles, hash, err := p.bf.BundleFromName(ctx, ref, ro)
+		// Attach a connection trace so that, if the fetch fails, the failure
+		// line can report which connection phase (DNS, connect, TLS, reuse, or
+		// time-to-first-byte) the request stalled in. The trace rides on the
+		// context, so it propagates to every registry call across retries.
+		fctx := ctx
+		var tc *fetcher.TraceCollector
+		if fetcher.TraceEnabled {
+			tc = fetcher.NewTraceCollector()
+			fctx = httptrace.WithClientTrace(ctx, tc.Trace())
+		}
+		bundles, hash, err := p.bf.BundleFromName(fctx, ref, ro)
 		dur := time.Since(start)
 		// Record the fetch latency for both successful and failed fetches.
 		// The tail of this histogram (failed fetches timing out) is a key
@@ -135,12 +146,19 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		if err != nil {
 			reason, step, attempts := fetcher.Classify(err)
 			metrics.AttestationsRetrieveFail.WithLabelValues(reason).Inc()
-			imgLog.Error("validate: error fetching bundles",
+			// The connection-phase fields ride on the existing failure line, so
+			// there is no added log volume on the success path.
+			fields := []any{
 				"reason", reason,
 				"step", step,
 				"attempts", attempts,
 				"duration_s", dur.Seconds(),
-				"error", err)
+				"error", err,
+			}
+			if tc != nil {
+				fields = append(fields, tc.Fields()...)
+			}
+			imgLog.Error("validate: error fetching bundles", fields...)
 			results = append(results, externaldata.Item{
 				Key:   key,
 				Error: "error_fetching_bundle_" + reason,

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/http/httptrace"
 	"strings"
 	"testing"
 
@@ -372,4 +373,119 @@ func TestValidateLogsImageContext(t *testing.T) {
 	assert.InDelta(t, 2.0, fetchErr["image_index"], 0.0001, "failure line should report the 1-based image position")
 	assert.Equal(t, entry["request_id"], fetchErr["request_id"],
 		"per-image failure line should carry the request's correlation id")
+}
+
+// traceProbeFetcher records whether a client trace was attached to the fetch
+// context and always fails, so the provider's failure-logging path runs and
+// its trace fields can be asserted.
+type traceProbeFetcher struct {
+	mockBundleFetcher
+	sawTrace bool
+}
+
+func (f *traceProbeFetcher) BundleFromName(ctx context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+	f.sawTrace = httptrace.ContextClientTrace(ctx) != nil
+	return nil, nil, &fetcher.FetchError{
+		Step:        fetcher.StepDescriptor,
+		Kind:        fetcher.KindTimeout,
+		Attempts:    3,
+		Recoverable: false,
+		Err:         context.DeadlineExceeded,
+	}
+}
+
+// lastLogLine returns the last JSON log entry in buf whose "msg" equals msg, or
+// nil if none is present.
+func lastLogLine(t *testing.T, buf *bytes.Buffer, msg string) map[string]any {
+	t.Helper()
+	var found map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &m))
+		if m["msg"] == msg {
+			found = m
+		}
+	}
+	return found
+}
+
+// TestValidateAttachesTraceAndLogsFieldsOnFailure verifies the provider wires a
+// client trace onto the fetch context when tracing is enabled and appends the
+// connection-phase fields to the failure log line.
+func TestValidateAttachesTraceAndLogsFieldsOnFailure(t *testing.T) {
+	prevTrace := fetcher.TraceEnabled
+	fetcher.TraceEnabled = true
+	defer func() { fetcher.TraceEnabled = prevTrace }()
+
+	v := &mockVerifier{}
+	kc := &mockKeyChainProvider{}
+	bf := &traceProbeFetcher{}
+	provider := New(v, kc, bf)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	request := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{validImageName},
+		},
+	}
+	provider.Validate(context.Background(), request)
+
+	assert.True(t, bf.sawTrace,
+		"fetch context should carry an httptrace.ClientTrace when tracing is enabled")
+
+	fetchErr := lastLogLine(t, &buf, "validate: error fetching bundles")
+	require.NotNil(t, fetchErr, "expected a fetch error log line")
+	// The connection-phase fields ride on the existing failure line.
+	assert.Contains(t, fetchErr, "ttfb_ms")
+	assert.Contains(t, fetchErr, "conns_new")
+	assert.Contains(t, fetchErr, "wrote_request")
+	// The pre-existing failure fields must survive alongside the new ones.
+	assert.Equal(t, "timeout", fetchErr["reason"])
+}
+
+// TestValidateOmitsTraceFieldsWhenDisabled verifies the -registry-trace kill
+// switch: with tracing disabled no trace is attached and the failure line
+// carries none of the connection-phase fields.
+func TestValidateOmitsTraceFieldsWhenDisabled(t *testing.T) {
+	prevTrace := fetcher.TraceEnabled
+	fetcher.TraceEnabled = false
+	defer func() { fetcher.TraceEnabled = prevTrace }()
+
+	v := &mockVerifier{}
+	kc := &mockKeyChainProvider{}
+	bf := &traceProbeFetcher{}
+	provider := New(v, kc, bf)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	request := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{validImageName},
+		},
+	}
+	provider.Validate(context.Background(), request)
+
+	assert.False(t, bf.sawTrace,
+		"fetch context should not carry a trace when tracing is disabled")
+
+	fetchErr := lastLogLine(t, &buf, "validate: error fetching bundles")
+	require.NotNil(t, fetchErr, "expected a fetch error log line")
+	assert.NotContains(t, fetchErr, "ttfb_ms")
+	assert.NotContains(t, fetchErr, "conns_new")
+	// The pre-existing failure fields are still present.
+	assert.Equal(t, "timeout", fetchErr["reason"])
 }


### PR DESCRIPTION
## Summary

Attach an `httptrace.ClientTrace` to each bundle fetch so that, when a fetch fails, the log line records **which connection phase was responsible** — DNS, TCP connect, TLS handshake, connection reuse (and how long a reused connection had been idle), whether the request was written, and time-to-first-byte.

Today a failure line reports the *step* (`descriptor`/`referrers`/`blob`) and *reason* (`timeout`/`canceled`) but not the underlying connection phase, so the failure mode has to be inferred rather than measured. This is a general-purpose diagnostic: when a fetch stalls and ages out, we want to see *where* it spent its time.

This is **pure observability** — no change to fetch behavior, timeouts, or the connection pool.

## Changes

- **`pkg/fetcher/trace.go`** (new): `TraceCollector`, a mutex-guarded collector that builds an `*httptrace.ClientTrace` and accumulates per-fetch connection counts plus the phase timings of the most recently used connection (the one in flight when a stall trips the per-attempt deadline). `Fields()` returns structured log key/values.
- **`pkg/provider/provider.go`**: wrap the fetch context with the trace when enabled and append the collector's fields to the **existing** failure log line — so there is no added log volume on the success path.
- **`cmd/aaop/aaop.go`**: add a `-registry-trace` flag (default on) that gates the instrumentation as a cheap kill-switch.
- **`pkg/fetcher/trace_test.go`** (new): unit tests driving the hooks directly (reused-connection black-hole signature, fresh-dial phase durations) plus `httptest` integration tests (real request through a transport, and a black-hole handler that never responds).

## Emitted fields (on failure lines)

`conns_reused`, `conns_new`, `last_conn_reused`, `last_conn_idle_ms`, `dns_ms`, `connect_ms`, `tls_ms`, `wrote_request`, `ttfb_ms`. A `ttfb_ms` of `-1` means no response byte was ever received on the last connection (the request was written into a connection that returned nothing before the deadline).

## Overhead

A handful of `time.Now()` captures per request; negligible, and gated by the flag regardless. All field access is mutex-guarded because `GotFirstResponseByte` can fire from the transport's read goroutine.

## Testing

- `go build ./...`
- `go test ./pkg/fetcher/... ./pkg/provider/...` (including `-race` on the new tests)
- `golangci-lint run` — clean

## Rollback

`-registry-trace=false`.