### PR TITLE
Record per-attempt fetch outcomes on the terminal error

### DIFF
--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -282,6 +282,20 @@ type BundleResult struct {
 	Bundles  []*bundle.Bundle
 	Hash     *v1.Hash
 	Attempts int
+	// Trail is the classified outcome of every attempt that failed before this
+	// result succeeded, oldest first. It is populated on the success path so a
+	// retry-rescued fetch can report the failures its final attempt masked;
+	// it is empty for a first-attempt success (len(Trail) == Attempts-1 on
+	// success). A failed fetch carries its trail on the returned *FetchError
+	// instead (see FetchError.Trail), so this stays empty there.
+	Trail []AttemptOutcome
+}
+
+// AttemptTrail renders this result's pre-success failure outcomes as the same
+// compact, ordered "reason:step" string produced for the failure path (see the
+// AttemptTrail function). It is the empty string for a first-attempt success.
+func (r BundleResult) AttemptTrail() string {
+	return formatAttemptTrail(r.Trail)
 }
 
 // BundleFromName fetches a sigstore bundle for a container from the OCI
@@ -337,10 +351,14 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 		b, h, err := attempt(ictx)
 		cancel()
 		if err == nil {
+			// outcomes here holds exactly the attempts that failed before this
+			// one; the winning attempt is never appended, so a first-attempt
+			// success carries an empty trail.
 			return BundleResult{
 				Bundles:  b,
 				Hash:     h,
 				Attempts: attempts,
+				Trail:    outcomes,
 			}, nil
 		}
 		lastErr = err
@@ -638,11 +656,22 @@ func Classify(err error) (reason string, step string, attempts int) {
 // safe as a log field; it must not be used as a metric label.
 func AttemptTrail(err error) string {
 	var fe *FetchError
-	if !errors.As(err, &fe) || len(fe.Trail) == 0 {
+	if !errors.As(err, &fe) {
 		return ""
 	}
-	tokens := make([]string, len(fe.Trail))
-	for i, o := range fe.Trail {
+	return formatAttemptTrail(fe.Trail)
+}
+
+// formatAttemptTrail renders a sequence of per-attempt outcomes as the compact
+// "reason:step" string documented on AttemptTrail. It is shared by the failure
+// path (FetchError.Trail via AttemptTrail) and the success path
+// (BundleResult.Trail via BundleResult.AttemptTrail).
+func formatAttemptTrail(outcomes []AttemptOutcome) string {
+	if len(outcomes) == 0 {
+		return ""
+	}
+	tokens := make([]string, len(outcomes))
+	for i, o := range outcomes {
 		reason := string(o.Reason)
 		if reason == "" {
 			reason = string(KindUnknown)

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -238,14 +238,28 @@ const (
 	StepDecode Step = "decode"
 )
 
+// AttemptOutcome is the classified result of a single fetch attempt. A slice of
+// these records the per-attempt history behind a retried fetch so a terminal
+// failure can report the outcomes that preceded it, not just the final one.
+type AttemptOutcome struct {
+	Reason FailureKind
+	Step   Step
+}
+
 // FetchError is a structured error describing a failed attempt to fetch a
 // bundle from an OCI registry. It records which Step failed, a stable failure
 // Kind, how many attempts were made, and (when known) the HTTP StatusCode, so
 // callers can log, categorize, and emit metrics without parsing error strings.
 type FetchError struct {
-	Step        Step
-	Kind        FailureKind
-	Attempts    int
+	Step     Step
+	Kind     FailureKind
+	Attempts int
+	// Trail is the classified outcome of every attempt, oldest first. It is
+	// additive to the terminal Kind/Step: when a retried fetch is cut short by
+	// a parent cancellation or deadline, the terminal reason alone hides the
+	// per-attempt failures that came before it, so Trail preserves them.
+	// len(Trail) == Attempts on every attempt-driven failure path.
+	Trail       []AttemptOutcome
 	StatusCode  int
 	Recoverable bool
 	Err         error
@@ -294,6 +308,10 @@ type bundleAttempt func(context.Context) ([]*bundle.Bundle, *v1.Hash, error)
 func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Duration, attempt bundleAttempt) (BundleResult, error) {
 	var lastErr error
 	var attempts int
+	// outcomes accumulates one entry per completed attempt, oldest first, and is
+	// attached to every failure return path so the terminal error carries the
+	// full per-attempt history (len(outcomes) == attempts on those paths).
+	var outcomes []AttemptOutcome
 
 	for i := 0; i < maxAttempts; i++ {
 		if i > 0 && delay > 0 {
@@ -304,6 +322,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 				return BundleResult{Attempts: attempts}, &FetchError{
 					Kind:        kindFromContext(ctx.Err()),
 					Attempts:    attempts,
+					Trail:       outcomes,
 					Recoverable: false,
 					Err:         ctx.Err(),
 				}
@@ -326,24 +345,32 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 		}
 		lastErr = err
 
+		// Record this attempt's classified outcome before any early return so
+		// the terminal error carries the reason for every attempt, not just the
+		// last. reason/step are reused by the debug log below.
+		reason, step, _ := Classify(err)
+		outcomes = append(outcomes, AttemptOutcome{Reason: FailureKind(reason), Step: Step(step)})
+
 		// Stop early on errors that a retry cannot fix (auth, invalid
 		// bundle). Record how many attempts we made for observability.
 		var fe *FetchError
 		if errors.As(err, &fe) && !fe.Recoverable {
 			fe.Attempts = attempts
+			fe.Trail = outcomes
 			return BundleResult{Attempts: attempts}, fe
 		}
 		if cerr := ctx.Err(); cerr != nil {
 			// Preserve the step from the in-flight attempt (if any) so
 			// cancellation failures still report where they occurred.
-			var step Step
+			var cstep Step
 			if fe != nil {
-				step = fe.Step
+				cstep = fe.Step
 			}
 			return BundleResult{Attempts: attempts}, &FetchError{
-				Step:        step,
+				Step:        cstep,
 				Kind:        kindFromContext(cerr),
 				Attempts:    attempts,
+				Trail:       outcomes,
 				Recoverable: false,
 				Err:         cerr,
 			}
@@ -351,7 +378,6 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 
 		// Log each retryable attempt failure at debug level so an operator
 		// can dig into the individual failures behind a retried fetch.
-		reason, step, _ := Classify(err)
 		slog.Debug("bundle fetch attempt failed",
 			"attempt", attempts,
 			"max_attempts", maxAttempts,
@@ -360,7 +386,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			"error", err)
 	}
 
-	return BundleResult{Attempts: attempts}, finalizeFetchError(lastErr, attempts)
+	return BundleResult{Attempts: attempts}, finalizeFetchError(lastErr, attempts, outcomes)
 }
 
 // DoBundleFromName fetches a sigstore bundle for a container from
@@ -537,8 +563,9 @@ func kindFromContext(err error) FailureKind {
 }
 
 // finalizeFetchError normalizes the error returned after all attempts are
-// exhausted into a FetchError carrying the total number of attempts.
-func finalizeFetchError(err error, attempts int) error {
+// exhausted into a FetchError carrying the total number of attempts and the
+// per-attempt outcome trail.
+func finalizeFetchError(err error, attempts int, outcomes []AttemptOutcome) error {
 	if err == nil {
 		// Defensive: this is only reached when the retry loop ran zero
 		// iterations (maxAttempts < 1), so no attempt was ever made.
@@ -551,6 +578,7 @@ func finalizeFetchError(err error, attempts int) error {
 	var fe *FetchError
 	if errors.As(err, &fe) {
 		fe.Attempts = attempts
+		fe.Trail = outcomes
 		return fe
 	}
 	kind, code := classifyTransport(err)
@@ -558,6 +586,7 @@ func finalizeFetchError(err error, attempts int) error {
 		Kind:        kind,
 		StatusCode:  code,
 		Attempts:    attempts,
+		Trail:       outcomes,
 		Recoverable: true,
 		Err:         err,
 	}
@@ -576,6 +605,29 @@ func Classify(err error) (reason string, step string, attempts int) {
 		return reason, string(fe.Step), fe.Attempts
 	}
 	return string(KindUnknown), "", 0
+}
+
+// AttemptTrail renders a fetch error's per-attempt outcomes as a compact,
+// ordered, low-cardinality string of "reason:step" tokens joined by commas
+// (e.g. "timeout:descriptor,timeout:descriptor,canceled:descriptor"), oldest
+// attempt first. It returns the empty string when err is not a *FetchError or
+// carries no recorded trail. The tokens reuse the same stable, low-cardinality
+// reason/step values as the terminal fields, so the result is safe as a log
+// field; it must not be used as a metric label.
+func AttemptTrail(err error) string {
+	var fe *FetchError
+	if !errors.As(err, &fe) || len(fe.Trail) == 0 {
+		return ""
+	}
+	tokens := make([]string, len(fe.Trail))
+	for i, o := range fe.Trail {
+		reason := string(o.Reason)
+		if reason == "" {
+			reason = string(KindUnknown)
+		}
+		tokens[i] = reason + ":" + string(o.Step)
+	}
+	return strings.Join(tokens, ",")
 }
 
 // GetRemoteOptions returns the options to provide when accessing remote

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -347,9 +347,11 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 
 		// Record this attempt's classified outcome before any early return so
 		// the terminal error carries the reason for every attempt, not just the
-		// last. reason/step are reused by the debug log below.
-		reason, step, _ := Classify(err)
-		outcomes = append(outcomes, AttemptOutcome{Reason: FailureKind(reason), Step: Step(step)})
+		// last. kind/step are reused by the debug log below. Non-*FetchError
+		// attempt errors are classified here too so the trail matches the
+		// terminal reason instead of collapsing to "unknown".
+		kind, step := classifyAttempt(err)
+		outcomes = append(outcomes, AttemptOutcome{Reason: kind, Step: step})
 
 		// Stop early on errors that a retry cannot fix (auth, invalid
 		// bundle). Record how many attempts we made for observability.
@@ -381,8 +383,8 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 		slog.Debug("bundle fetch attempt failed",
 			"attempt", attempts,
 			"max_attempts", maxAttempts,
-			"reason", reason,
-			"step", step,
+			"reason", string(kind),
+			"step", string(step),
 			"error", err)
 	}
 
@@ -550,6 +552,25 @@ func classifyTransport(err error) (FailureKind, int) {
 	return KindUnknown, 0
 }
 
+// classifyAttempt derives a single attempt's outcome (reason and step) for the
+// per-attempt trail. A *FetchError already carries both. Any other error (a raw
+// context or transport error, e.g. an attempt that returns ctx.Err() directly)
+// is run through classifyTransport so its reason is accurate — matching how
+// finalizeFetchError classifies the same terminal error — rather than being
+// recorded as "unknown". Such raw errors carry no fetch step.
+func classifyAttempt(err error) (FailureKind, Step) {
+	var fe *FetchError
+	if errors.As(err, &fe) {
+		kind := fe.Kind
+		if kind == "" {
+			kind = KindUnknown
+		}
+		return kind, fe.Step
+	}
+	kind, _ := classifyTransport(err)
+	return kind, ""
+}
+
 // kindFromContext classifies a context error.
 func kindFromContext(err error) FailureKind {
 	switch {
@@ -610,10 +631,11 @@ func Classify(err error) (reason string, step string, attempts int) {
 // AttemptTrail renders a fetch error's per-attempt outcomes as a compact,
 // ordered, low-cardinality string of "reason:step" tokens joined by commas
 // (e.g. "timeout:descriptor,timeout:descriptor,canceled:descriptor"), oldest
-// attempt first. It returns the empty string when err is not a *FetchError or
-// carries no recorded trail. The tokens reuse the same stable, low-cardinality
-// reason/step values as the terminal fields, so the result is safe as a log
-// field; it must not be used as a metric label.
+// attempt first. An outcome with no fetch step (a raw context/transport error)
+// renders as just its reason. It returns the empty string when err is not a
+// *FetchError or carries no recorded trail. The tokens reuse the same stable,
+// low-cardinality reason/step values as the terminal fields, so the result is
+// safe as a log field; it must not be used as a metric label.
 func AttemptTrail(err error) string {
 	var fe *FetchError
 	if !errors.As(err, &fe) || len(fe.Trail) == 0 {
@@ -624,6 +646,10 @@ func AttemptTrail(err error) string {
 		reason := string(o.Reason)
 		if reason == "" {
 			reason = string(KindUnknown)
+		}
+		if o.Step == "" {
+			tokens[i] = reason
+			continue
 		}
 		tokens[i] = reason + ":" + string(o.Step)
 	}

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -411,18 +412,24 @@ func TestRetryBundleTrailStopsOnNonRecoverable(t *testing.T) {
 }
 
 func TestRetryBundleTrailCarriesPriorAttemptsOnDelayCancel(t *testing.T) {
-	// Fail the first attempt recoverably without touching the parent, then
-	// cancel the parent while the loop is waiting out the inter-attempt delay.
-	// The terminal error is the delay-branch cancel (no in-flight step), but it
-	// must still carry the first attempt's outcome.
+	// Drive the delay-branch cancel deterministically instead of racing a
+	// wall-clock timer: retryBundle emits its per-attempt debug log immediately
+	// before the inter-attempt delay select, so a handler that cancels the
+	// parent on that log guarantees the next select observes cancellation. The
+	// handler runs synchronously in retryBundle's own goroutine, so there is no
+	// timing dependency. The terminal error is the delay-branch cancel (no
+	// in-flight step) but must still carry the first attempt's outcome.
 	ctx, cancel := context.WithCancel(t.Context())
-	var attempts int
+	prev := slog.Default()
+	slog.SetDefault(slog.New(&cancelOnMessage{msg: "bundle fetch attempt failed", cancel: cancel}))
+	defer slog.SetDefault(prev)
 
-	_, _, err := retryBundle(ctx, 3, time.Second, 250*time.Millisecond, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	var attempts int
+	// A long delay so the select can only return via the (already canceled)
+	// parent, never the timer; if the debug hook ever stops firing the test
+	// fails fast on assertions rather than hanging on the timer.
+	_, _, err := retryBundle(ctx, 3, time.Second, 5*time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
-		// Cancel well after this attempt's post-return context check but well
-		// before the 250ms delay timer, so the cancel lands in the delay branch.
-		time.AfterFunc(20*time.Millisecond, cancel)
 		return nil, nil, newDescriptorError(context.DeadlineExceeded)
 	})
 
@@ -435,6 +442,30 @@ func TestRetryBundleTrailCarriesPriorAttemptsOnDelayCancel(t *testing.T) {
 	require.Len(t, fe.Trail, 1)
 	assert.Equal(t, AttemptOutcome{Reason: KindTimeout, Step: StepDescriptor}, fe.Trail[0])
 	assert.Equal(t, "timeout:descriptor", AttemptTrail(err))
+	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+}
+
+func TestRetryBundleTrailClassifiesNonFetchErrors(t *testing.T) {
+	// An attempt may return a raw (non-*FetchError) error, e.g. ctx.Err()
+	// directly. The trail must classify it the same way the terminal error is
+	// classified rather than recording it as "unknown".
+	const maxAttempts = 3
+
+	_, _, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindTimeout, fe.Kind, "terminal reason is classified from the raw error")
+	require.Len(t, fe.Trail, maxAttempts)
+	for i, o := range fe.Trail {
+		assert.Equal(t, KindTimeout, o.Reason, "attempt %d trail must match the terminal reason, not unknown", i)
+		assert.Empty(t, o.Step, "a raw attempt error carries no fetch step")
+	}
+	// A stepless outcome renders as just its reason (no trailing separator).
+	assert.Equal(t, "timeout,timeout,timeout", AttemptTrail(err))
 	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
 }
 
@@ -455,7 +486,37 @@ func TestAttemptTrail(t *testing.T) {
 
 	// A missing reason falls back to "unknown" so the token is never bare.
 	assert.Equal(t, "unknown:blob", AttemptTrail(&FetchError{Trail: []AttemptOutcome{{Step: StepBlob}}}))
+
+	// A stepless outcome renders as just its reason, with no trailing separator.
+	assert.Equal(t, "timeout,canceled", AttemptTrail(&FetchError{Trail: []AttemptOutcome{
+		{Reason: KindTimeout},
+		{Reason: KindCanceled},
+	}}))
 }
+
+// cancelOnMessage is a slog.Handler that invokes cancel whenever it sees a
+// record with the given message. retryBundle logs each retryable attempt
+// failure immediately before the inter-attempt delay select, so canceling from
+// this handler deterministically steers the loop into the delay-branch cancel
+// path without depending on wall-clock timing. Handle runs synchronously in the
+// caller's goroutine.
+type cancelOnMessage struct {
+	msg    string
+	cancel context.CancelFunc
+}
+
+func (*cancelOnMessage) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *cancelOnMessage) Handle(_ context.Context, r slog.Record) error {
+	if r.Message == h.msg {
+		h.cancel()
+	}
+	return nil
+}
+
+func (h *cancelOnMessage) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *cancelOnMessage) WithGroup(string) slog.Handler { return h }
 
 func TestResolveTransportTimeoutsDerivesFromBudget(t *testing.T) {
 	// With no overrides, each phase is a fraction of the per-attempt budget.

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -353,7 +353,7 @@ func TestRetryBundleTrailDeMasksTerminalCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	var attempts int
 
-	_, _, err := retryBundle(ctx, 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(ctx, 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		if attempts < 3 {
 			return nil, nil, newDescriptorError(context.DeadlineExceeded)
@@ -373,12 +373,13 @@ func TestRetryBundleTrailDeMasksTerminalCancellation(t *testing.T) {
 	assert.Equal(t, AttemptOutcome{Reason: KindCanceled, Step: StepDescriptor}, fe.Trail[2])
 	assert.Equal(t, "timeout:descriptor,timeout:descriptor,canceled:descriptor", AttemptTrail(err))
 	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+	assert.Equal(t, fe.Attempts, result.Attempts, "BundleResult.Attempts agrees with FetchError.Attempts")
 }
 
 func TestRetryBundleTrailRecordsExhaustedRetries(t *testing.T) {
 	const maxAttempts = 3
 
-	_, _, err := retryBundle(t.Context(), maxAttempts, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), maxAttempts, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		return nil, nil, newReferrersError(errors.New("boom"))
 	})
 
@@ -391,12 +392,13 @@ func TestRetryBundleTrailRecordsExhaustedRetries(t *testing.T) {
 		assert.Equal(t, AttemptOutcome{Reason: KindReferrersUnavailable, Step: StepReferrers}, o, "attempt %d", i)
 	}
 	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+	assert.Equal(t, fe.Attempts, result.Attempts, "BundleResult.Attempts agrees with FetchError.Attempts")
 }
 
 func TestRetryBundleTrailStopsOnNonRecoverable(t *testing.T) {
 	var attempts int
 
-	_, _, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, newFetchError(StepDescriptor, KindDescriptorError, &transport.Error{StatusCode: http.StatusUnauthorized})
 	})
@@ -409,6 +411,7 @@ func TestRetryBundleTrailStopsOnNonRecoverable(t *testing.T) {
 	assert.Equal(t, AttemptOutcome{Reason: KindUnauthorized, Step: StepDescriptor}, fe.Trail[0])
 	assert.Equal(t, "unauthorized:descriptor", AttemptTrail(err))
 	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+	assert.Equal(t, fe.Attempts, result.Attempts, "BundleResult.Attempts agrees with FetchError.Attempts")
 }
 
 func TestRetryBundleTrailCarriesPriorAttemptsOnDelayCancel(t *testing.T) {
@@ -428,7 +431,7 @@ func TestRetryBundleTrailCarriesPriorAttemptsOnDelayCancel(t *testing.T) {
 	// A long delay so the select can only return via the (already canceled)
 	// parent, never the timer; if the debug hook ever stops firing the test
 	// fails fast on assertions rather than hanging on the timer.
-	_, _, err := retryBundle(ctx, 3, time.Second, 5*time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, err := retryBundle(ctx, 3, time.Second, 5*time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, newDescriptorError(context.DeadlineExceeded)
 	})
@@ -451,7 +454,7 @@ func TestRetryBundleTrailClassifiesNonFetchErrors(t *testing.T) {
 	// classified rather than recording it as "unknown".
 	const maxAttempts = 3
 
-	_, _, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		<-ctx.Done()
 		return nil, nil, ctx.Err()
 	})
@@ -467,6 +470,48 @@ func TestRetryBundleTrailClassifiesNonFetchErrors(t *testing.T) {
 	// A stepless outcome renders as just its reason (no trailing separator).
 	assert.Equal(t, "timeout,timeout,timeout", AttemptTrail(err))
 	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+	assert.Equal(t, fe.Attempts, result.Attempts, "BundleResult.Attempts agrees with FetchError.Attempts")
+}
+
+func TestRetryBundleSuccessCarriesPriorFailureTrail(t *testing.T) {
+	// A fetch that fails twice recoverably then succeeds must surface the two
+	// prior failures on the successful result, so a retry-rescued success does
+	// not silently hide them. The winning attempt is not itself a failure, so
+	// len(Trail) == Attempts-1.
+	expectedBundles := []*bundle.Bundle{{}}
+	expectedHash := &v1.Hash{Algorithm: "sha256", Hex: "abc"}
+	var attempts int
+
+	result, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, nil, newDescriptorError(context.DeadlineExceeded)
+		}
+		return expectedBundles, expectedHash, nil
+	})
+
+	require.NoError(t, err)
+	assert.Same(t, expectedBundles[0], result.Bundles[0])
+	assert.Same(t, expectedHash, result.Hash)
+	assert.Equal(t, 3, result.Attempts)
+	require.Len(t, result.Trail, 2)
+	assert.Equal(t, AttemptOutcome{Reason: KindTimeout, Step: StepDescriptor}, result.Trail[0])
+	assert.Equal(t, AttemptOutcome{Reason: KindTimeout, Step: StepDescriptor}, result.Trail[1])
+	assert.Equal(t, "timeout:descriptor,timeout:descriptor", result.AttemptTrail())
+	assert.Len(t, result.Trail, result.Attempts-1, "len(Trail) == Attempts-1 on success")
+}
+
+func TestRetryBundleFirstAttemptSuccessHasEmptyTrail(t *testing.T) {
+	// The common case: a first-attempt success records no prior failures, so
+	// the trail is empty and renders to nothing (the provider omits the field).
+	result, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		return []*bundle.Bundle{{}}, &v1.Hash{Algorithm: "sha256", Hex: "abc"}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Attempts)
+	assert.Empty(t, result.Trail)
+	assert.Empty(t, result.AttemptTrail())
 }
 
 func TestAttemptTrail(t *testing.T) {
@@ -492,6 +537,14 @@ func TestAttemptTrail(t *testing.T) {
 		{Reason: KindTimeout},
 		{Reason: KindCanceled},
 	}}))
+
+	// BundleResult.AttemptTrail renders its prior-failure trail the same way,
+	// and is empty when there were no prior failures.
+	assert.Empty(t, BundleResult{Attempts: 1}.AttemptTrail())
+	assert.Equal(t, "timeout:descriptor,timeout:descriptor", BundleResult{Attempts: 3, Trail: []AttemptOutcome{
+		{Reason: KindTimeout, Step: StepDescriptor},
+		{Reason: KindTimeout, Step: StepDescriptor},
+	}}.AttemptTrail())
 }
 
 // cancelOnMessage is a slog.Handler that invokes cancel whenever it sees a

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -344,6 +344,119 @@ func TestRetryBundleStopsOnNotFound(t *testing.T) {
 	assert.Equal(t, 1, fe.Attempts)
 }
 
+func TestRetryBundleTrailDeMasksTerminalCancellation(t *testing.T) {
+	// Two establishment stalls (recoverable timeout on the descriptor GET),
+	// then the parent context is canceled partway through the third attempt.
+	// The terminal reason stays the honest "canceled", but the trail must
+	// preserve the two prior timeouts that reason alone would mask.
+	ctx, cancel := context.WithCancel(t.Context())
+	var attempts int
+
+	_, _, err := retryBundle(ctx, 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, nil, newDescriptorError(context.DeadlineExceeded)
+		}
+		cancel()
+		return nil, nil, newDescriptorError(context.Canceled)
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindCanceled, fe.Kind, "terminal reason stays the true final state")
+	assert.Equal(t, StepDescriptor, fe.Step)
+	assert.Equal(t, 3, fe.Attempts)
+	require.Len(t, fe.Trail, 3)
+	assert.Equal(t, AttemptOutcome{Reason: KindTimeout, Step: StepDescriptor}, fe.Trail[0])
+	assert.Equal(t, AttemptOutcome{Reason: KindTimeout, Step: StepDescriptor}, fe.Trail[1])
+	assert.Equal(t, AttemptOutcome{Reason: KindCanceled, Step: StepDescriptor}, fe.Trail[2])
+	assert.Equal(t, "timeout:descriptor,timeout:descriptor,canceled:descriptor", AttemptTrail(err))
+	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+}
+
+func TestRetryBundleTrailRecordsExhaustedRetries(t *testing.T) {
+	const maxAttempts = 3
+
+	_, _, err := retryBundle(t.Context(), maxAttempts, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		return nil, nil, newReferrersError(errors.New("boom"))
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, KindReferrersUnavailable, fe.Kind, "terminal reason is the last attempt's reason")
+	assert.Equal(t, maxAttempts, fe.Attempts)
+	require.Len(t, fe.Trail, maxAttempts)
+	for i, o := range fe.Trail {
+		assert.Equal(t, AttemptOutcome{Reason: KindReferrersUnavailable, Step: StepReferrers}, o, "attempt %d", i)
+	}
+	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+}
+
+func TestRetryBundleTrailStopsOnNonRecoverable(t *testing.T) {
+	var attempts int
+
+	_, _, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		attempts++
+		return nil, nil, newFetchError(StepDescriptor, KindDescriptorError, &transport.Error{StatusCode: http.StatusUnauthorized})
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, 1, attempts, "a non-recoverable error must not be retried")
+	assert.Equal(t, KindUnauthorized, fe.Kind)
+	require.Len(t, fe.Trail, 1)
+	assert.Equal(t, AttemptOutcome{Reason: KindUnauthorized, Step: StepDescriptor}, fe.Trail[0])
+	assert.Equal(t, "unauthorized:descriptor", AttemptTrail(err))
+	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+}
+
+func TestRetryBundleTrailCarriesPriorAttemptsOnDelayCancel(t *testing.T) {
+	// Fail the first attempt recoverably without touching the parent, then
+	// cancel the parent while the loop is waiting out the inter-attempt delay.
+	// The terminal error is the delay-branch cancel (no in-flight step), but it
+	// must still carry the first attempt's outcome.
+	ctx, cancel := context.WithCancel(t.Context())
+	var attempts int
+
+	_, _, err := retryBundle(ctx, 3, time.Second, 250*time.Millisecond, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+		attempts++
+		// Cancel well after this attempt's post-return context check but well
+		// before the 250ms delay timer, so the cancel lands in the delay branch.
+		time.AfterFunc(20*time.Millisecond, cancel)
+		return nil, nil, newDescriptorError(context.DeadlineExceeded)
+	})
+
+	var fe *FetchError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, 1, attempts, "cancel during the delay must stop before a second attempt")
+	assert.Equal(t, KindCanceled, fe.Kind)
+	assert.Empty(t, fe.Step, "the delay-branch cancel has no in-flight step")
+	assert.Equal(t, 1, fe.Attempts)
+	require.Len(t, fe.Trail, 1)
+	assert.Equal(t, AttemptOutcome{Reason: KindTimeout, Step: StepDescriptor}, fe.Trail[0])
+	assert.Equal(t, "timeout:descriptor", AttemptTrail(err))
+	assert.Len(t, fe.Trail, fe.Attempts, "len(Trail) == Attempts")
+}
+
+func TestAttemptTrail(t *testing.T) {
+	// A non-*FetchError carries no trail.
+	assert.Empty(t, AttemptTrail(errors.New("boom")))
+	// A *FetchError with no recorded trail renders empty.
+	assert.Empty(t, AttemptTrail(&FetchError{Kind: KindCanceled}))
+
+	// Outcomes render as ordered "reason:step" tokens, oldest first.
+	fe := &FetchError{Trail: []AttemptOutcome{
+		{Reason: KindTimeout, Step: StepDescriptor},
+		{Reason: KindCanceled, Step: StepReferrers},
+	}}
+	assert.Equal(t, "timeout:descriptor,canceled:referrers", AttemptTrail(fe))
+	// A wrapped *FetchError is still rendered.
+	assert.Equal(t, "timeout:descriptor,canceled:referrers", AttemptTrail(fmt.Errorf("wrapped: %w", fe)))
+
+	// A missing reason falls back to "unknown" so the token is never bare.
+	assert.Equal(t, "unknown:blob", AttemptTrail(&FetchError{Trail: []AttemptOutcome{{Step: StepBlob}}}))
+}
+
 func TestResolveTransportTimeoutsDerivesFromBudget(t *testing.T) {
 	// With no overrides, each phase is a fraction of the per-attempt budget.
 	// At a 2.5s budget this reproduces the values this change originally

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -168,10 +168,19 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		}
 
 		metrics.AttestationsRetrieved.Add(float64(len(result.Bundles)))
-		imgLog.Info("validate: fetched OCI bundles",
+		fetchedFields := []any{
 			"count", len(result.Bundles),
 			"duration_s", dur.Seconds(),
-			"attempts", result.Attempts)
+			"attempts", result.Attempts,
+		}
+		// A retry-rescued fetch (more than one attempt) succeeded only after
+		// earlier attempts failed; surface those prior outcomes so a success
+		// that masked real fetch failures is still visible. A first-attempt
+		// success adds nothing, so the field stays off the common path.
+		if result.Attempts > 1 {
+			fetchedFields = append(fetchedFields, "attempt_trail", result.AttemptTrail())
+		}
+		imgLog.Info("validate: fetched OCI bundles", fetchedFields...)
 
 		if len(result.Bundles) == 0 {
 			metrics.AttestationsMissing.Inc()

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -152,6 +152,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 				"reason", reason,
 				"step", step,
 				"attempts", errAttempts,
+				"attempt_trail", fetcher.AttemptTrail(err),
 				"duration_s", dur.Seconds(),
 				"error", err,
 			}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -494,3 +494,54 @@ func TestValidateOmitsTraceFieldsWhenDisabled(t *testing.T) {
 	// The pre-existing failure fields are still present.
 	assert.Equal(t, "timeout", fetchErr["reason"])
 }
+
+// trailFetcher always fails with a FetchError that carries a per-attempt trail,
+// so the provider's failure-logging path can be asserted to surface it.
+type trailFetcher struct {
+	mockBundleFetcher
+}
+
+func (*trailFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+	return nil, nil, &fetcher.FetchError{
+		Step:     fetcher.StepDescriptor,
+		Kind:     fetcher.KindCanceled,
+		Attempts: 3,
+		Trail: []fetcher.AttemptOutcome{
+			{Reason: fetcher.KindTimeout, Step: fetcher.StepDescriptor},
+			{Reason: fetcher.KindTimeout, Step: fetcher.StepDescriptor},
+			{Reason: fetcher.KindCanceled, Step: fetcher.StepDescriptor},
+		},
+		Recoverable: false,
+		Err:         context.Canceled,
+	}
+}
+
+// TestValidateLogsAttemptTrailOnFailure verifies the provider surfaces the
+// per-attempt trail on the fetch failure line, so a terminal cancellation does
+// not hide the establishment timeouts that preceded it.
+func TestValidateLogsAttemptTrailOnFailure(t *testing.T) {
+	v := &mockVerifier{}
+	kc := &mockKeyChainProvider{}
+	bf := &trailFetcher{}
+	provider := New(v, kc, bf)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	request := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{validImageName},
+		},
+	}
+	provider.Validate(context.Background(), request)
+
+	fetchErr := lastLogLine(t, &buf, "validate: error fetching bundles")
+	require.NotNil(t, fetchErr, "expected a fetch error log line")
+	// The terminal reason stays honest, and the trail rides alongside it.
+	assert.Equal(t, "canceled", fetchErr["reason"])
+	assert.Equal(t, "timeout:descriptor,timeout:descriptor,canceled:descriptor", fetchErr["attempt_trail"])
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -501,8 +501,8 @@ type trailFetcher struct {
 	mockBundleFetcher
 }
 
-func (*trailFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
-	return nil, nil, &fetcher.FetchError{
+func (*trailFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) (fetcher.BundleResult, error) {
+	return fetcher.BundleResult{Attempts: 3}, &fetcher.FetchError{
 		Step:     fetcher.StepDescriptor,
 		Kind:     fetcher.KindCanceled,
 		Attempts: 3,
@@ -544,4 +544,81 @@ func TestValidateLogsAttemptTrailOnFailure(t *testing.T) {
 	// The terminal reason stays honest, and the trail rides alongside it.
 	assert.Equal(t, "canceled", fetchErr["reason"])
 	assert.Equal(t, "timeout:descriptor,timeout:descriptor,canceled:descriptor", fetchErr["attempt_trail"])
+}
+
+// rescuedSuccessFetcher returns a successful result that only succeeded after
+// earlier attempts failed, carrying their outcomes on the result's trail.
+type rescuedSuccessFetcher struct {
+	mockBundleFetcher
+}
+
+func (*rescuedSuccessFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) (fetcher.BundleResult, error) {
+	return fetcher.BundleResult{
+		Bundles:  []*bundle.Bundle{{}},
+		Hash:     &v1.Hash{Algorithm: "sha256", Hex: "abc"},
+		Attempts: 3,
+		Trail: []fetcher.AttemptOutcome{
+			{Reason: fetcher.KindTimeout, Step: fetcher.StepDescriptor},
+			{Reason: fetcher.KindTimeout, Step: fetcher.StepDescriptor},
+		},
+	}, nil
+}
+
+// TestValidateLogsAttemptTrailOnRescuedSuccess verifies that a fetch which
+// succeeded only after earlier failures surfaces those failures on the success
+// line, so a retry-rescued success does not hide them.
+func TestValidateLogsAttemptTrailOnRescuedSuccess(t *testing.T) {
+	v := &mockVerifier{}
+	kc := &mockKeyChainProvider{}
+	bf := &rescuedSuccessFetcher{}
+	provider := New(v, kc, bf)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	request := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{validImageName},
+		},
+	}
+	provider.Validate(context.Background(), request)
+
+	fetched := lastLogLine(t, &buf, "validate: fetched OCI bundles")
+	require.NotNil(t, fetched, "expected a fetch success log line")
+	assert.InDelta(t, 3.0, fetched["attempts"], 0.0001)
+	assert.Equal(t, "timeout:descriptor,timeout:descriptor", fetched["attempt_trail"])
+}
+
+// TestValidateOmitsAttemptTrailOnFirstAttemptSuccess verifies the common case:
+// a first-attempt success reports attempts=1 and no attempt_trail, so the field
+// stays off the success path when there is nothing to surface.
+func TestValidateOmitsAttemptTrailOnFirstAttemptSuccess(t *testing.T) {
+	v := &mockVerifier{}
+	kc := &mockKeyChainProvider{}
+	bf := &mockBundleFetcher{}
+	provider := New(v, kc, bf)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	request := &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{validImageName},
+		},
+	}
+	provider.Validate(context.Background(), request)
+
+	fetched := lastLogLine(t, &buf, "validate: fetched OCI bundles")
+	require.NotNil(t, fetched, "expected a fetch success log line")
+	assert.InDelta(t, 1.0, fetched["attempts"], 0.0001)
+	assert.NotContains(t, fetched, "attempt_trail",
+		"a first-attempt success must not carry an attempt_trail field")
 }


### PR DESCRIPTION
## What

When a retried bundle fetch is exhausted or cut short, `retryBundle` reports a single **terminal** `reason` (e.g. `canceled`). If the parent context is canceled after one or more attempts already failed for a *different*, recoverable reason (e.g. connection-establishment timeouts), those per-attempt failures were only visible at `slog.Debug` — off in production. So an operator sees `reason=canceled` and concludes "the caller gave up," missing that the fetch was **independently failing on every attempt**.

This change records each attempt's classified outcome and carries it alongside — not replacing — the honest terminal `reason`:

```
reason=canceled … attempts=3 attempt_trail="timeout:descriptor,timeout:descriptor,canceled:descriptor"
```

The same masking happens on **success**: a fetch rescued by a retry logs `attempts=3` but not *why* the earlier attempts failed. The trail closes that gap too:

```
validate: fetched OCI bundles … attempts=3 attempt_trail="timeout:descriptor,timeout:descriptor"
```

## How

- `pkg/fetcher/bundle.go`: add `AttemptOutcome` and a `Trail []AttemptOutcome` field on `FetchError`; accumulate an outcome per attempt in `retryBundle` and attach the trail to every failure return path (including the delay-branch cancel); thread it through `finalizeFetchError`. `classifyAttempt` classifies raw (non-`FetchError`) attempt errors so the trail matches the terminal reason. `AttemptTrail(err)` renders the ordered, low-cardinality `reason:step` tokens.
- **Success path:** carry the prior-failure outcomes on `BundleResult.Trail` (empty on a first-attempt success) with a `BundleResult.AttemptTrail()` renderer sharing the same formatter.
- `pkg/provider/provider.go`: add `attempt_trail` to the existing `"validate: error fetching bundles"` failure line, and to the `"validate: fetched OCI bundles"` success line when `attempts > 1`.

## Guarantees

- **Pure observability** — the terminal `Kind`/`Step`/`Attempts` and all retry control flow are unchanged; the trail is strictly additive and the terminal reason stays the true final state.
- **Bounded** — `Trail` length ≤ `max-attempts` (single digits).
- `attempt_trail` is a log field, not a metric label; the `reason:step` tokens are low-cardinality and safe. A first-attempt success (the common case) omits the field entirely.

## Tests

Coverage in `pkg/fetcher/bundle_test.go` and `pkg/provider/provider_test.go` for: the cancel-after-timeouts masking case, exhausted retries, non-recoverable early return, the deterministic delay-branch cancel, raw-error classification, the retry-rescued success trail, first-attempt success omission, and the `AttemptTrail`/`BundleResult.AttemptTrail` formatters. `go build ./... && go test ./... -race` and `golangci-lint run` pass.