### PR TITLE
Log attempts for success

### DIFF
--- a/cmd/cver/cver.go
+++ b/cmd/cver/cver.go
@@ -131,9 +131,11 @@ func main() {
 			log.Print(err)
 		}
 		ctx := context.Background()
-		if b, h, _, err = fetcher.BundleFromName(ctx, ref, remoteOpts); err != nil {
+		var result fetcher.BundleResult
+		if result, err = fetcher.BundleFromName(ctx, ref, remoteOpts); err != nil {
 			log.Print(err)
 		}
+		b, h = result.Bundles, result.Hash
 	}
 
 	if res, err = v.Verify(b, h); err != nil {

--- a/cmd/cver/cver.go
+++ b/cmd/cver/cver.go
@@ -131,7 +131,7 @@ func main() {
 			log.Print(err)
 		}
 		ctx := context.Background()
-		if b, h, err = fetcher.BundleFromName(ctx, ref, remoteOpts); err != nil {
+		if b, h, _, err = fetcher.BundleFromName(ctx, ref, remoteOpts); err != nil {
 			log.Print(err)
 		}
 	}

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -263,9 +263,16 @@ func (e *FetchError) Unwrap() error {
 // DefaultBundleFetcher is the default implementation of the BundleFetcher.
 type DefaultBundleFetcher struct{}
 
+// BundleResult contains the bundles and metadata returned by a fetch.
+type BundleResult struct {
+	Bundles  []*bundle.Bundle
+	Hash     *v1.Hash
+	Attempts int
+}
+
 // BundleFromName fetches a sigstore bundle for a container from the OCI
 // registry.
-func (*DefaultBundleFetcher) BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error) {
+func (*DefaultBundleFetcher) BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) (BundleResult, error) {
 	return BundleFromName(ctx, ref, ro)
 }
 
@@ -276,7 +283,7 @@ func (*DefaultBundleFetcher) GetRemoteOptions(kc authn.Keychain) []remote.Option
 
 // BundleFromName fetches a sigstore bundle for a container from
 // a registry with retry.
-func BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error) {
+func BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) (BundleResult, error) {
 	return retryBundle(ctx, MaxAttempts, Timeout, Delay, func(attemptCtx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		return DoBundleFromName(attemptCtx, ref, ro)
 	})
@@ -284,7 +291,7 @@ func BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option)
 
 type bundleAttempt func(context.Context) ([]*bundle.Bundle, *v1.Hash, error)
 
-func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Duration, attempt bundleAttempt) ([]*bundle.Bundle, *v1.Hash, int, error) {
+func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Duration, attempt bundleAttempt) (BundleResult, error) {
 	var lastErr error
 	var attempts int
 
@@ -294,7 +301,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			select {
 			case <-ctx.Done():
 				t.Stop()
-				return nil, nil, attempts, &FetchError{
+				return BundleResult{Attempts: attempts}, &FetchError{
 					Kind:        kindFromContext(ctx.Err()),
 					Attempts:    attempts,
 					Recoverable: false,
@@ -311,7 +318,11 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 		b, h, err := attempt(ictx)
 		cancel()
 		if err == nil {
-			return b, h, attempts, nil
+			return BundleResult{
+				Bundles:  b,
+				Hash:     h,
+				Attempts: attempts,
+			}, nil
 		}
 		lastErr = err
 
@@ -320,7 +331,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 		var fe *FetchError
 		if errors.As(err, &fe) && !fe.Recoverable {
 			fe.Attempts = attempts
-			return nil, nil, attempts, fe
+			return BundleResult{Attempts: attempts}, fe
 		}
 		if cerr := ctx.Err(); cerr != nil {
 			// Preserve the step from the in-flight attempt (if any) so
@@ -329,7 +340,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			if fe != nil {
 				step = fe.Step
 			}
-			return nil, nil, attempts, &FetchError{
+			return BundleResult{Attempts: attempts}, &FetchError{
 				Step:        step,
 				Kind:        kindFromContext(cerr),
 				Attempts:    attempts,
@@ -349,7 +360,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			"error", err)
 	}
 
-	return nil, nil, attempts, finalizeFetchError(lastErr, attempts)
+	return BundleResult{Attempts: attempts}, finalizeFetchError(lastErr, attempts)
 }
 
 // DoBundleFromName fetches a sigstore bundle for a container from

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -265,7 +265,7 @@ type DefaultBundleFetcher struct{}
 
 // BundleFromName fetches a sigstore bundle for a container from the OCI
 // registry.
-func (*DefaultBundleFetcher) BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+func (*DefaultBundleFetcher) BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error) {
 	return BundleFromName(ctx, ref, ro)
 }
 
@@ -276,7 +276,7 @@ func (*DefaultBundleFetcher) GetRemoteOptions(kc authn.Keychain) []remote.Option
 
 // BundleFromName fetches a sigstore bundle for a container from
 // a registry with retry.
-func BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+func BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error) {
 	return retryBundle(ctx, MaxAttempts, Timeout, Delay, func(attemptCtx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		return DoBundleFromName(attemptCtx, ref, ro)
 	})
@@ -284,7 +284,7 @@ func BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option)
 
 type bundleAttempt func(context.Context) ([]*bundle.Bundle, *v1.Hash, error)
 
-func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Duration, attempt bundleAttempt) ([]*bundle.Bundle, *v1.Hash, error) {
+func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Duration, attempt bundleAttempt) ([]*bundle.Bundle, *v1.Hash, int, error) {
 	var lastErr error
 	var attempts int
 
@@ -294,7 +294,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			select {
 			case <-ctx.Done():
 				t.Stop()
-				return nil, nil, &FetchError{
+				return nil, nil, attempts, &FetchError{
 					Kind:        kindFromContext(ctx.Err()),
 					Attempts:    attempts,
 					Recoverable: false,
@@ -311,7 +311,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 		b, h, err := attempt(ictx)
 		cancel()
 		if err == nil {
-			return b, h, nil
+			return b, h, attempts, nil
 		}
 		lastErr = err
 
@@ -320,7 +320,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 		var fe *FetchError
 		if errors.As(err, &fe) && !fe.Recoverable {
 			fe.Attempts = attempts
-			return nil, nil, fe
+			return nil, nil, attempts, fe
 		}
 		if cerr := ctx.Err(); cerr != nil {
 			// Preserve the step from the in-flight attempt (if any) so
@@ -329,7 +329,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			if fe != nil {
 				step = fe.Step
 			}
-			return nil, nil, &FetchError{
+			return nil, nil, attempts, &FetchError{
 				Step:        step,
 				Kind:        kindFromContext(cerr),
 				Attempts:    attempts,
@@ -349,7 +349,7 @@ func retryBundle(ctx context.Context, maxAttempts int, timeout, delay time.Durat
 			"error", err)
 	}
 
-	return nil, nil, finalizeFetchError(lastErr, attempts)
+	return nil, nil, attempts, finalizeFetchError(lastErr, attempts)
 }
 
 // DoBundleFromName fetches a sigstore bundle for a container from

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -29,14 +29,14 @@ func TestRetryBundleTimesOutEachAttempt(t *testing.T) {
 	const maxAttempts = 3
 	var attempts int
 
-	_, _, finalAttempts, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		<-ctx.Done()
 		return nil, nil, ctx.Err()
 	})
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, maxAttempts, finalAttempts)
+	assert.Equal(t, maxAttempts, result.Attempts)
 }
 
 func TestRetryBundleReturnsSuccessfulAttempt(t *testing.T) {
@@ -44,7 +44,7 @@ func TestRetryBundleReturnsSuccessfulAttempt(t *testing.T) {
 	expectedHash := &v1.Hash{Algorithm: "sha256", Hex: "abc"}
 	var attempts int
 
-	bundles, hash, finalAttempts, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		if attempts < 3 {
 			return nil, nil, errors.New("temporary failure")
@@ -53,23 +53,23 @@ func TestRetryBundleReturnsSuccessfulAttempt(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, attempts, finalAttempts)
-	assert.Same(t, expectedBundles[0], bundles[0])
-	assert.Same(t, expectedHash, hash)
+	assert.Equal(t, attempts, result.Attempts)
+	assert.Same(t, expectedBundles[0], result.Bundles[0])
+	assert.Same(t, expectedHash, result.Hash)
 }
 
 func TestRetryBundleStopsWhenParentIsCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	var attempts int
 
-	_, _, finalAttempts, err := retryBundle(ctx, 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(ctx, 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		cancel()
 		return nil, nil, errors.New("temporary failure")
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
-	assert.Equal(t, finalAttempts, attempts)
+	assert.Equal(t, result.Attempts, attempts)
 }
 
 func TestRetryBundleReturnsLastError(t *testing.T) {
@@ -77,7 +77,7 @@ func TestRetryBundleReturnsLastError(t *testing.T) {
 	lastErr := errors.New("last failure")
 	attempts := 0
 
-	_, _, finalAttempts, err := retryBundle(t.Context(), 2, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), 2, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		if attempts == 1 {
 			return nil, nil, firstErr
@@ -86,8 +86,8 @@ func TestRetryBundleReturnsLastError(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, lastErr)
-	assert.NotErrorIs(t, err, firstErr)
-	assert.Equal(t, attempts, finalAttempts)
+	require.NotErrorIs(t, err, firstErr)
+	assert.Equal(t, attempts, result.Attempts)
 }
 
 func TestClassifyTransport(t *testing.T) {
@@ -241,7 +241,7 @@ func TestNewFetchErrorClassifiesThrottling(t *testing.T) {
 func TestRetryBundleFailsFastOnThrottle(t *testing.T) {
 	var attempts int
 
-	_, _, finalAttempts, err := retryBundle(t.Context(), 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, newBlobError(&transport.Error{StatusCode: http.StatusTooManyRequests})
 	})
@@ -252,7 +252,7 @@ func TestRetryBundleFailsFastOnThrottle(t *testing.T) {
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindThrottled, fe.Kind)
 	assert.Equal(t, 1, fe.Attempts)
-	assert.Equal(t, fe.Attempts, finalAttempts)
+	assert.Equal(t, fe.Attempts, result.Attempts)
 }
 
 func TestNewFetchErrorRetriesThrottlingWhenEnabled(t *testing.T) {
@@ -271,7 +271,7 @@ func TestRetryBundleRetriesThrottleWhenEnabled(t *testing.T) {
 	const maxAttempts = 3
 	var attempts int
 
-	_, _, finalAttempts, err := retryBundle(t.Context(), maxAttempts, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), maxAttempts, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, newBlobError(&transport.Error{StatusCode: http.StatusTooManyRequests})
 	})
@@ -282,13 +282,13 @@ func TestRetryBundleRetriesThrottleWhenEnabled(t *testing.T) {
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindThrottled, fe.Kind)
 	assert.Equal(t, maxAttempts, fe.Attempts)
-	assert.Equal(t, finalAttempts, attempts)
+	assert.Equal(t, result.Attempts, attempts)
 }
 
 func TestRetryBundlePreservesStepOnCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
-	_, _, _, err := retryBundle(ctx, 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, err := retryBundle(ctx, 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		cancel()
 		return nil, nil, newReferrersError(errors.New("boom"))
 	})
@@ -302,7 +302,7 @@ func TestRetryBundlePreservesStepOnCancellation(t *testing.T) {
 func TestRetryBundleTimeoutSetsAttemptsAndReason(t *testing.T) {
 	const maxAttempts = 3
 
-	_, _, _, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		<-ctx.Done()
 		return nil, nil, newFetchError(StepDescriptor, KindDescriptorError, ctx.Err())
 	})
@@ -316,7 +316,7 @@ func TestRetryBundleTimeoutSetsAttemptsAndReason(t *testing.T) {
 func TestRetryBundleStopsOnNonRecoverableFetchError(t *testing.T) {
 	var attempts int
 
-	_, _, finalAttempts, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, &FetchError{Step: StepDescriptor, Kind: KindUnauthorized, Recoverable: false, Err: errors.New("401")}
 	})
@@ -324,14 +324,14 @@ func TestRetryBundleStopsOnNonRecoverableFetchError(t *testing.T) {
 	var fe *FetchError
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindUnauthorized, fe.Kind)
-	assert.Equal(t, 1, finalAttempts)
+	assert.Equal(t, 1, result.Attempts)
 	assert.Equal(t, 1, fe.Attempts)
 }
 
 func TestRetryBundleStopsOnNotFound(t *testing.T) {
 	var attempts int
 
-	_, _, finalAttempts, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	result, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, newDescriptorError(&transport.Error{StatusCode: http.StatusNotFound})
 	})
@@ -340,7 +340,7 @@ func TestRetryBundleStopsOnNotFound(t *testing.T) {
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindNotFound, fe.Kind)
 	assert.Equal(t, http.StatusNotFound, fe.StatusCode)
-	assert.Equal(t, 1, finalAttempts, "a 404 must not be retried")
+	assert.Equal(t, 1, result.Attempts, "a 404 must not be retried")
 	assert.Equal(t, 1, fe.Attempts)
 }
 

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -29,14 +29,14 @@ func TestRetryBundleTimesOutEachAttempt(t *testing.T) {
 	const maxAttempts = 3
 	var attempts int
 
-	_, _, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, finalAttempts, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		<-ctx.Done()
 		return nil, nil, ctx.Err()
 	})
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, maxAttempts, attempts)
+	assert.Equal(t, maxAttempts, finalAttempts)
 }
 
 func TestRetryBundleReturnsSuccessfulAttempt(t *testing.T) {
@@ -44,7 +44,7 @@ func TestRetryBundleReturnsSuccessfulAttempt(t *testing.T) {
 	expectedHash := &v1.Hash{Algorithm: "sha256", Hex: "abc"}
 	var attempts int
 
-	bundles, hash, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	bundles, hash, finalAttempts, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		if attempts < 3 {
 			return nil, nil, errors.New("temporary failure")
@@ -53,7 +53,7 @@ func TestRetryBundleReturnsSuccessfulAttempt(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, 3, attempts)
+	assert.Equal(t, attempts, finalAttempts)
 	assert.Same(t, expectedBundles[0], bundles[0])
 	assert.Same(t, expectedHash, hash)
 }
@@ -62,14 +62,14 @@ func TestRetryBundleStopsWhenParentIsCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	var attempts int
 
-	_, _, err := retryBundle(ctx, 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, finalAttempts, err := retryBundle(ctx, 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		cancel()
 		return nil, nil, errors.New("temporary failure")
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
-	assert.Equal(t, 1, attempts)
+	assert.Equal(t, finalAttempts, attempts)
 }
 
 func TestRetryBundleReturnsLastError(t *testing.T) {
@@ -77,7 +77,7 @@ func TestRetryBundleReturnsLastError(t *testing.T) {
 	lastErr := errors.New("last failure")
 	attempts := 0
 
-	_, _, err := retryBundle(t.Context(), 2, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, finalAttempts, err := retryBundle(t.Context(), 2, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		if attempts == 1 {
 			return nil, nil, firstErr
@@ -87,6 +87,7 @@ func TestRetryBundleReturnsLastError(t *testing.T) {
 
 	require.ErrorIs(t, err, lastErr)
 	assert.NotErrorIs(t, err, firstErr)
+	assert.Equal(t, attempts, finalAttempts)
 }
 
 func TestClassifyTransport(t *testing.T) {
@@ -240,7 +241,7 @@ func TestNewFetchErrorClassifiesThrottling(t *testing.T) {
 func TestRetryBundleFailsFastOnThrottle(t *testing.T) {
 	var attempts int
 
-	_, _, err := retryBundle(t.Context(), 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, finalAttempts, err := retryBundle(t.Context(), 3, time.Second, time.Second, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, newBlobError(&transport.Error{StatusCode: http.StatusTooManyRequests})
 	})
@@ -251,6 +252,7 @@ func TestRetryBundleFailsFastOnThrottle(t *testing.T) {
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindThrottled, fe.Kind)
 	assert.Equal(t, 1, fe.Attempts)
+	assert.Equal(t, fe.Attempts, finalAttempts)
 }
 
 func TestNewFetchErrorRetriesThrottlingWhenEnabled(t *testing.T) {
@@ -269,7 +271,7 @@ func TestRetryBundleRetriesThrottleWhenEnabled(t *testing.T) {
 	const maxAttempts = 3
 	var attempts int
 
-	_, _, err := retryBundle(t.Context(), maxAttempts, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, finalAttempts, err := retryBundle(t.Context(), maxAttempts, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, newBlobError(&transport.Error{StatusCode: http.StatusTooManyRequests})
 	})
@@ -280,12 +282,13 @@ func TestRetryBundleRetriesThrottleWhenEnabled(t *testing.T) {
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindThrottled, fe.Kind)
 	assert.Equal(t, maxAttempts, fe.Attempts)
+	assert.Equal(t, finalAttempts, attempts)
 }
 
 func TestRetryBundlePreservesStepOnCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
-	_, _, err := retryBundle(ctx, 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, _, err := retryBundle(ctx, 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		cancel()
 		return nil, nil, newReferrersError(errors.New("boom"))
 	})
@@ -299,7 +302,7 @@ func TestRetryBundlePreservesStepOnCancellation(t *testing.T) {
 func TestRetryBundleTimeoutSetsAttemptsAndReason(t *testing.T) {
 	const maxAttempts = 3
 
-	_, _, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, _, err := retryBundle(t.Context(), maxAttempts, 5*time.Millisecond, 0, func(ctx context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		<-ctx.Done()
 		return nil, nil, newFetchError(StepDescriptor, KindDescriptorError, ctx.Err())
 	})
@@ -313,7 +316,7 @@ func TestRetryBundleTimeoutSetsAttemptsAndReason(t *testing.T) {
 func TestRetryBundleStopsOnNonRecoverableFetchError(t *testing.T) {
 	var attempts int
 
-	_, _, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, finalAttempts, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, &FetchError{Step: StepDescriptor, Kind: KindUnauthorized, Recoverable: false, Err: errors.New("401")}
 	})
@@ -321,14 +324,14 @@ func TestRetryBundleStopsOnNonRecoverableFetchError(t *testing.T) {
 	var fe *FetchError
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindUnauthorized, fe.Kind)
-	assert.Equal(t, 1, attempts)
+	assert.Equal(t, 1, finalAttempts)
 	assert.Equal(t, 1, fe.Attempts)
 }
 
 func TestRetryBundleStopsOnNotFound(t *testing.T) {
 	var attempts int
 
-	_, _, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
+	_, _, finalAttempts, err := retryBundle(t.Context(), 3, time.Second, 0, func(context.Context) ([]*bundle.Bundle, *v1.Hash, error) {
 		attempts++
 		return nil, nil, newDescriptorError(&transport.Error{StatusCode: http.StatusNotFound})
 	})
@@ -337,7 +340,7 @@ func TestRetryBundleStopsOnNotFound(t *testing.T) {
 	require.ErrorAs(t, err, &fe)
 	assert.Equal(t, KindNotFound, fe.Kind)
 	assert.Equal(t, http.StatusNotFound, fe.StatusCode)
-	assert.Equal(t, 1, attempts, "a 404 must not be retried")
+	assert.Equal(t, 1, finalAttempts, "a 404 must not be retried")
 	assert.Equal(t, 1, fe.Attempts)
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -36,7 +36,7 @@ type KeyChainProvider interface {
 
 // BundleFetcher fetches bundles from a remote OCI registry.
 type BundleFetcher interface {
-	BundleFromName(ctx context.Context, ref name.Reference, remoteOpts []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error)
+	BundleFromName(ctx context.Context, ref name.Reference, remoteOpts []remote.Option) (fetcher.BundleResult, error)
 	GetRemoteOptions(kc authn.Keychain) []remote.Option
 }
 
@@ -124,7 +124,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		}
 
 		start := time.Now()
-		bundles, hash, attempts, err := p.bf.BundleFromName(ctx, ref, ro)
+		result, err := p.bf.BundleFromName(ctx, ref, ro)
 		dur := time.Since(start)
 		// Record the fetch latency for both successful and failed fetches.
 		// The tail of this histogram (failed fetches timing out) is a key
@@ -133,12 +133,12 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		metrics.AttestationsPullTimer.Observe(dur.Seconds())
 
 		if err != nil {
-			reason, step, _ := fetcher.Classify(err)
+			reason, step, errAttempts := fetcher.Classify(err)
 			metrics.AttestationsRetrieveFail.WithLabelValues(reason).Inc()
 			imgLog.Error("validate: error fetching bundles",
 				"reason", reason,
 				"step", step,
-				"attempts", attempts,
+				"attempts", errAttempts,
 				"duration_s", dur.Seconds(),
 				"error", err)
 			results = append(results, externaldata.Item{
@@ -148,13 +148,13 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 			continue
 		}
 
-		metrics.AttestationsRetrieved.Add(float64(len(bundles)))
+		metrics.AttestationsRetrieved.Add(float64(len(result.Bundles)))
 		imgLog.Info("validate: fetched OCI bundles",
-			"count", len(bundles),
+			"count", len(result.Bundles),
 			"duration_s", dur.Seconds(),
-			"attempts", attempts)
+			"attempts", result.Attempts)
 
-		if len(bundles) == 0 {
+		if len(result.Bundles) == 0 {
 			metrics.AttestationsMissing.Inc()
 			imgLog.Info("validate: no bundles")
 			results = append(results, externaldata.Item{
@@ -165,18 +165,18 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		}
 
 		start = time.Now()
-		res, err = p.v.Verify(bundles, hash)
+		res, err = p.v.Verify(result.Bundles, result.Hash)
 		dur = time.Since(start)
 		metrics.AttestationsVerTimer.Observe(dur.Seconds())
 		metrics.AttestationsVerOk.Add(float64(len(res)))
-		var fail = len(bundles) - len(res)
+		var fail = len(result.Bundles) - len(res)
 		if fail > 0 {
 			metrics.AttestationsVerFail.Add(float64(fail))
 		}
 
 		if err != nil {
 			imgLog.Error("validate: verification error",
-				"image_digest", hash.Hex,
+				"image_digest", result.Hash.Hex,
 				"error", err)
 			return ErrorResponse(fmt.Sprintf("ERROR: VerifyImageSignatures(%q): %v", key, err))
 		}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -36,7 +36,7 @@ type KeyChainProvider interface {
 
 // BundleFetcher fetches bundles from a remote OCI registry.
 type BundleFetcher interface {
-	BundleFromName(ctx context.Context, ref name.Reference, remoteOpts []remote.Option) ([]*bundle.Bundle, *v1.Hash, error)
+	BundleFromName(ctx context.Context, ref name.Reference, remoteOpts []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error)
 	GetRemoteOptions(kc authn.Keychain) []remote.Option
 }
 
@@ -124,7 +124,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		}
 
 		start := time.Now()
-		bundles, hash, err := p.bf.BundleFromName(ctx, ref, ro)
+		bundles, hash, attempts, err := p.bf.BundleFromName(ctx, ref, ro)
 		dur := time.Since(start)
 		// Record the fetch latency for both successful and failed fetches.
 		// The tail of this histogram (failed fetches timing out) is a key
@@ -133,7 +133,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		metrics.AttestationsPullTimer.Observe(dur.Seconds())
 
 		if err != nil {
-			reason, step, attempts := fetcher.Classify(err)
+			reason, step, _ := fetcher.Classify(err)
 			metrics.AttestationsRetrieveFail.WithLabelValues(reason).Inc()
 			imgLog.Error("validate: error fetching bundles",
 				"reason", reason,
@@ -151,7 +151,8 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		metrics.AttestationsRetrieved.Add(float64(len(bundles)))
 		imgLog.Info("validate: fetched OCI bundles",
 			"count", len(bundles),
-			"duration_s", dur.Seconds())
+			"duration_s", dur.Seconds(),
+			"attempts", attempts)
 
 		if len(bundles) == 0 {
 			metrics.AttestationsMissing.Inc()

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -94,21 +94,25 @@ func (*mockKeyChainProvider) KeyChain(_ context.Context) (authn.Keychain, error)
 type mockBundleFetcher struct {
 }
 
-func (*mockBundleFetcher) BundleFromName(_ context.Context, ref name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error) {
+func (*mockBundleFetcher) BundleFromName(_ context.Context, ref name.Reference, _ []remote.Option) (fetcher.BundleResult, error) {
 	if mb, ok := bundles[ref.Name()]; ok {
 		var b bundle.Bundle
 		err := b.UnmarshalJSON([]byte(mb.bundle))
 		if err != nil {
-			return nil, nil, 1, err
+			return fetcher.BundleResult{Attempts: 1}, err
 		}
 		h := v1.Hash{
 			Algorithm: "sha256",
 			Hex:       mb.hash,
 		}
-		return []*bundle.Bundle{&b}, &h, 1, nil
+		return fetcher.BundleResult{
+			Bundles:  []*bundle.Bundle{&b},
+			Hash:     &h,
+			Attempts: 1,
+		}, nil
 	}
 
-	return nil, nil, 1, nil
+	return fetcher.BundleResult{Attempts: 1}, nil
 }
 
 func (*mockBundleFetcher) GetRemoteOptions(_ authn.Keychain) []remote.Option {
@@ -254,8 +258,8 @@ type notFoundBundleFetcher struct {
 	mockBundleFetcher
 }
 
-func (*notFoundBundleFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error) {
-	return nil, nil, 1, &fetcher.FetchError{
+func (*notFoundBundleFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) (fetcher.BundleResult, error) {
+	return fetcher.BundleResult{Attempts: 1}, &fetcher.FetchError{
 		Step:        fetcher.StepDescriptor,
 		Kind:        fetcher.KindNotFound,
 		Attempts:    1,
@@ -322,8 +326,8 @@ func TestValidateRecordsImageCount(t *testing.T) {
 }
 
 // TestValidateLogsImageContext verifies that per-image log lines carry the
-// request-scoped context (request_id, image_count, image_index) so a failed
-// image fetch can be traced back to a solo vs. multi-image request.
+// request-scoped context (request_id, image_count, image_index, attempts) so
+// a failed image fetch can be traced back to a solo vs. multi-image request.
 func TestValidateLogsImageContext(t *testing.T) {
 	v := &mockVerifier{}
 	kc := &mockKeyChainProvider{}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -94,21 +94,21 @@ func (*mockKeyChainProvider) KeyChain(_ context.Context) (authn.Keychain, error)
 type mockBundleFetcher struct {
 }
 
-func (*mockBundleFetcher) BundleFromName(_ context.Context, ref name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
+func (*mockBundleFetcher) BundleFromName(_ context.Context, ref name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error) {
 	if mb, ok := bundles[ref.Name()]; ok {
 		var b bundle.Bundle
 		err := b.UnmarshalJSON([]byte(mb.bundle))
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 1, err
 		}
 		h := v1.Hash{
 			Algorithm: "sha256",
 			Hex:       mb.hash,
 		}
-		return []*bundle.Bundle{&b}, &h, nil
+		return []*bundle.Bundle{&b}, &h, 1, nil
 	}
 
-	return nil, nil, nil
+	return nil, nil, 1, nil
 }
 
 func (*mockBundleFetcher) GetRemoteOptions(_ authn.Keychain) []remote.Option {
@@ -254,8 +254,8 @@ type notFoundBundleFetcher struct {
 	mockBundleFetcher
 }
 
-func (*notFoundBundleFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, error) {
-	return nil, nil, &fetcher.FetchError{
+func (*notFoundBundleFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) ([]*bundle.Bundle, *v1.Hash, int, error) {
+	return nil, nil, 1, &fetcher.FetchError{
 		Step:        fetcher.StepDescriptor,
 		Kind:        fetcher.KindNotFound,
 		Attempts:    1,

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -374,6 +374,7 @@ func TestValidateLogsImageContext(t *testing.T) {
 	// fetchErr is the last "error fetching bundles" line, i.e. the second
 	// image, so its 1-based image_index must be 2.
 	assert.InDelta(t, 2.0, fetchErr["image_index"], 0.0001, "failure line should report the 1-based image position")
+	assert.InDelta(t, 1.0, fetchErr["attempts"], 0.0001, "failure line should report the fetch attempt count")
 	assert.Equal(t, entry["request_id"], fetchErr["request_id"],
 		"per-image failure line should carry the request's correlation id")
 }


### PR DESCRIPTION
This change refactors BundleForName to return BundleResult which contains what was originally returned (list of bundles, hash) and the number of attempts to fetch the bundle. This allows for logging of attempts for success cases which could be useful in detecting failures that are hidden by retries. The attempts count has been left in place on FetchErrors. 