### PR TITLE
Dimension fetch-failure and latency metrics and add config-info gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,23 +244,34 @@ The metrics exposed beyond the default Prometheus metrics are:
   attestations downloaded from the OCI registry.
 * `aaop_attestations_retrieved_fail`: the total number of
   failed bundle fetches from the OCI registry. Labeled by `reason`
-  (e.g. `timeout`, `throttled`, `unauthorized`, `forbidden`,
-  `referrers_unavailable`, `descriptor_error`, `blob_error`,
-  `bundle_invalid`, `unknown`).
+  (e.g. `timeout`, `canceled`, `throttled`, `unauthorized`, `forbidden`,
+  `not_found`, `referrers_unavailable`, `descriptor_error`, `blob_error`,
+  `bundle_invalid`, `unknown`), `step` (the fetch stage that failed:
+  `descriptor`, `referrers`, `blob`, or `decode`), and `status` (the
+  registry HTTP status code; `0` means no numeric status was recorded —
+  the registry never responded, or its response carried no numeric status,
+  such as a diagnostic-only throttle).
 * `aaop_attestations_verified_ok`: the total number of verified
   attestations.
 * `aaop_attestations_verified_fail`: the total number of
   attestations that failed to verify.
 * `aaop_attestations_request_timer`: the duration in seconds for
-  the validation webhook.
-* `aaop_attestations_request_images`: a histogram of the number of
-  images (keys) included in a single provider request. Gatekeeper sends
-  all of a pod's images in one request, so this captures the pod's image
-  count. Use the `_bucket`/`_count`/`_sum` series to analyze the
-  distribution of images per request (e.g. single-image vs. multi-image
-  pods) and to see whether large multi-image requests are common.
-* `aaop_attestations_retrieved_timer`: the duration in seconds for the
-   time it takes to download the attestations from the OCI registry.
+  the validation webhook. Labeled by `images` (the number of images/keys
+  in the request; Gatekeeper sends all of a pod's images in one request, so
+  this is the pod's image count — recorded exactly up to a small cap, with
+  larger counts folded into a `10+` bucket to keep cardinality bounded) and
+  `outcome` (`success` when every image verified cleanly, otherwise
+  `failure`). Because this is a histogram vector, the total request count is
+  the sum of the `_count` series across all label values (e.g.
+  `sum(aaop_attestations_request_timer_count)`); the `images` label carries
+  the per-request image-count distribution (e.g. single-image vs.
+  multi-image pods).
+* `aaop_attestations_retrieved_timer`: the duration in seconds to fetch
+  the attestations for a single image from the OCI registry, recorded for
+  both successful and failed fetches. Labeled by `outcome` (`success` or
+  `failure`) and, on failure, `reason` and `step` (matching
+  `aaop_attestations_retrieved_fail`) plus `attempts` (the number of fetch
+  attempts made). Successful fetches use `reason`/`step` of `none`.
 * `aaop_attestations_verification_timer`: the duration in seconds for
   the time it takes to verify the retrieved attestations.
 * `aaop_keychain_build_timer`: the duration in seconds to build the
@@ -269,6 +280,10 @@ The metrics exposed beyond the default Prometheus metrics are:
 * `aaop_keychain_refresh_fail`: the total number of background keychain
   refreshes that did not fully rebuild the keychain (a failed or degraded
   rebuild), so the previous keychain was retained.
+* `aaop_config_info`: a gauge whose value is always `1`, exposing the
+  effective fetch configuration as labels (`bundle_timeout`,
+  `bundle_max_attempts`, `bundle_delay`, `retry_throttled`) so the
+  in-force configuration can be compared across instances.
 
 Each request is also logged with a `request_id`, `image_count`, and, for
 per-image log lines, an `image_index` (1-based position within the

--- a/cmd/aaop/aaop.go
+++ b/cmd/aaop/aaop.go
@@ -22,6 +22,7 @@ import (
 	"github.com/github/artifact-attestations-opa-provider/pkg/authn"
 	"github.com/github/artifact-attestations-opa-provider/pkg/cainjector"
 	"github.com/github/artifact-attestations-opa-provider/pkg/fetcher"
+	"github.com/github/artifact-attestations-opa-provider/pkg/metrics"
 	"github.com/github/artifact-attestations-opa-provider/pkg/provider"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/v1beta1"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
@@ -93,6 +94,12 @@ func main() {
 	}
 	fetcher.RetryThrottled = *bundleRetryThrottled
 	fetcher.TraceEnabled = *registryTrace
+
+	// Publish the effective fetch configuration as a config-info gauge, reading
+	// the values after configureBundleFetcher has applied them so the metric
+	// reflects what is actually in force. Emitted before the metrics server
+	// starts serving so it is present on first scrape.
+	metrics.SetConfigInfo(fetcher.Timeout, fetcher.MaxAttempts, fetcher.Delay, fetcher.RetryThrottled)
 
 	var vCfg = app.VerifierCfg{
 		TufRoot: *tufRoot,

--- a/pkg/fetcher/bundle.go
+++ b/pkg/fetcher/bundle.go
@@ -646,6 +646,22 @@ func Classify(err error) (reason string, step string, attempts int) {
 	return string(KindUnknown), "", 0
 }
 
+// FailureStatus returns the HTTP status code recorded on a fetch failure, or 0
+// when no numeric status was recorded. A nonzero value means the registry
+// answered with that status; 0 means the status is unavailable — either the
+// registry never responded (a connection-level failure), or the response
+// carried no numeric status (e.g. a diagnostic-only throttle), or the error is
+// not a fetch error. It is a small, non-breaking companion to Classify so
+// callers can dimension metrics by the registry status without widening
+// Classify's signature.
+func FailureStatus(err error) int {
+	var fe *FetchError
+	if errors.As(err, &fe) {
+		return fe.StatusCode
+	}
+	return 0
+}
+
 // AttemptTrail renders a fetch error's per-attempt outcomes as a compact,
 // ordered, low-cardinality string of "reason:step" tokens joined by commas
 // (e.g. "timeout:descriptor,timeout:descriptor,canceled:descriptor"), oldest

--- a/pkg/fetcher/bundle_test.go
+++ b/pkg/fetcher/bundle_test.go
@@ -197,6 +197,25 @@ func TestClassify(t *testing.T) {
 	assert.Equal(t, "timeout", reason)
 }
 
+func TestFailureStatus(t *testing.T) {
+	// A registry that answered with an error carries its status code.
+	assert.Equal(t, http.StatusNotFound,
+		FailureStatus(&FetchError{Step: StepDescriptor, Kind: KindNotFound, StatusCode: http.StatusNotFound}))
+	assert.Equal(t, http.StatusTooManyRequests,
+		FailureStatus(&FetchError{Step: StepReferrers, Kind: KindThrottled, StatusCode: http.StatusTooManyRequests}))
+
+	// A connection-level failure carries no registry response: status 0.
+	assert.Equal(t, 0,
+		FailureStatus(&FetchError{Step: StepDescriptor, Kind: KindTimeout, Err: context.DeadlineExceeded}))
+
+	// A plain (non-fetch) error also has no status.
+	assert.Equal(t, 0, FailureStatus(errors.New("some other error")))
+
+	// The status is recovered through a wrapped error.
+	assert.Equal(t, http.StatusForbidden,
+		FailureStatus(fmt.Errorf("wrapped: %w", &FetchError{StatusCode: http.StatusForbidden})))
+}
+
 func TestFetchErrorErrorAndUnwrap(t *testing.T) {
 	inner := errors.New("boom")
 	fe := &FetchError{Step: StepBlob, Kind: KindBlobError, Attempts: 2, StatusCode: 500, Err: inner}

--- a/pkg/metrics/prom.go
+++ b/pkg/metrics/prom.go
@@ -1,9 +1,21 @@
 package metrics //nolint:revive
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+// fetchBuckets resolves the per-image fetch-latency body and the failure tail:
+// the success percentiles, the connection-phase boundaries, the fixed failure
+// walls, and the long cancellations that the default buckets (which top out at
+// 10s) collapse into +Inf.
+var fetchBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 2.5, 3, 4, 6, 8, 10, 15, 30, 60}
+
+// requestBuckets resolves the whole-request ceilings and the tail beyond them.
+var requestBuckets = []float64{0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 20, 30, 60}
 
 var (
 	//nolint: revive
@@ -15,8 +27,8 @@ var (
 	//nolint: revive
 	AttestationsRetrieveFail = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "aaop_attestations_retrieved_fail",
-		Help: "The total number of attestations retrieve failure",
-	}, []string{"reason"})
+		Help: "The total number of attestation fetch failures, by reason, fetch step, and registry HTTP status (0 when no numeric status was recorded)",
+	}, []string{"reason", "step", "status"})
 
 	//nolint: revive
 	AttestationsMissing = promauto.NewCounter(prometheus.CounterOpts{
@@ -37,10 +49,11 @@ var (
 	})
 
 	//nolint: revive
-	AttestationsPullTimer = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "aaop_attestations_retrieved_timer",
-		Help: "The duration (seconds) for fetching attestations from the OCI registry",
-	})
+	AttestationsPullTimer = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "aaop_attestations_retrieved_timer",
+		Help:    "The duration (seconds) for fetching attestations for a single image from the OCI registry, labelled by outcome and (on failure) reason, fetch step, and attempts",
+		Buckets: fetchBuckets,
+	}, []string{"outcome", "reason", "step", "attempts"})
 
 	//nolint: revive
 	AttestationsVerTimer = promauto.NewHistogram(prometheus.HistogramOpts{
@@ -49,22 +62,17 @@ var (
 	})
 
 	//nolint: revive
-	AttestationsReqTimer = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "aaop_attestations_request_timer",
-		Help: "The duration (seconds) for the entire request processing",
-	})
-
-	//nolint: revive
-	AttestationsReqImages = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "aaop_attestations_request_images",
-		Help:    "The number of images (keys) included in a single provider request",
-		Buckets: []float64{1, 2, 3, 5, 10, 20, 50},
-	})
+	AttestationsReqTimer = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "aaop_attestations_request_timer",
+		Help:    "The duration (seconds) for the entire request processing, labelled by image count and outcome (whether every image verified cleanly)",
+		Buckets: requestBuckets,
+	}, []string{"images", "outcome"})
 
 	//nolint: revive
 	KeychainBuildTimer = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "aaop_keychain_build_timer",
-		Help: "The duration (seconds) to build the registry keychain",
+		Name:    "aaop_keychain_build_timer",
+		Help:    "The duration (seconds) to build the registry keychain",
+		Buckets: append(prometheus.DefBuckets, 15, 30),
 	})
 
 	//nolint: revive
@@ -72,4 +80,22 @@ var (
 		Name: "aaop_keychain_refresh_fail",
 		Help: "The total number of background keychain refreshes that failed or were degraded (did not fully rebuild the keychain), leaving the previous keychain in place",
 	})
+
+	//nolint: revive
+	ConfigInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aaop_config_info",
+		Help: "The effective fetch configuration; value is always 1",
+	}, []string{"bundle_timeout", "bundle_max_attempts", "bundle_delay", "retry_throttled"})
 )
+
+// SetConfigInfo records the effective fetch configuration as a single always-1
+// gauge series so config can be compared across instances at a glance. It is
+// defined here so prom.go stays the single definition site for every metric.
+func SetConfigInfo(bundleTimeout time.Duration, maxAttempts int, delay time.Duration, retryThrottled bool) {
+	ConfigInfo.WithLabelValues(
+		bundleTimeout.String(),
+		strconv.Itoa(maxAttempts),
+		delay.String(),
+		strconv.FormatBool(retryThrottled),
+	).Set(1)
+}

--- a/pkg/metrics/prom_test.go
+++ b/pkg/metrics/prom_test.go
@@ -1,0 +1,23 @@
+package metrics //nolint:revive
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSetConfigInfo verifies the config-info gauge records exactly one always-1
+// series carrying the effective fetch configuration.
+func TestSetConfigInfo(t *testing.T) {
+	SetConfigInfo(2500*time.Millisecond, 3, 250*time.Millisecond, false)
+
+	// Exactly one config-info series is emitted.
+	assert.Equal(t, 1, testutil.CollectAndCount(ConfigInfo, "aaop_config_info"))
+
+	// It is the always-1 gauge with the expected label values (durations render
+	// via time.Duration.String, so 2.5s and 250ms).
+	g := ConfigInfo.WithLabelValues("2.5s", "3", "250ms", "false")
+	assert.InDelta(t, 1.0, testutil.ToFloat64(g), 0.0001)
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http/httptrace"
+	"strconv"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -76,28 +77,40 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 	var rstart = time.Now()
 	var err error
 
-	defer func() {
-		var dur = time.Since(rstart)
-		metrics.AttestationsReqTimer.Observe(dur.Seconds())
-	}()
-
 	// Record the number of images (keys) in this request. Gatekeeper sends
 	// every image in a pod as a single request, so this captures the pod's
 	// image count. request_id/image_count/image_index are threaded through the
 	// per-image logs below so a single failure line (e.g. a fetch timeout) can
 	// be traced back to whether it was a solo or a large multi-image request.
 	var imageCount = len(r.Request.Keys)
+
+	// allOK tracks whether every image in the request verified cleanly. Any
+	// branch below that records an image error (or fails the whole request)
+	// clears it, so the request timer can be split into totally-successful vs
+	// not. It is declared before the deferred observe so the closure captures
+	// it, and read only at return.
+	allOK := true
+	defer func() {
+		outcome := "success"
+		if !allOK {
+			outcome = "failure"
+		}
+		metrics.AttestationsReqTimer.
+			WithLabelValues(imageCountLabel(imageCount), outcome).
+			Observe(time.Since(rstart).Seconds())
+	}()
+
 	var requestID = uuid.NewString()
 	var reqLog = slog.With(
 		"request_id", requestID,
 		"image_count", imageCount)
-	metrics.AttestationsReqImages.Observe(float64(imageCount))
 	reqLog.Info("validate: received request")
 
 	// Get the keychain to be able to access the OCI registry.
 	// If the keychain configured is empty, the default keychain is used
 	// which works for public registries.
 	if kc, err = p.kc.KeyChain(ctx); err != nil {
+		allOK = false
 		reqLog.Error("validate: error retrieving key chain",
 			"error", err)
 		return ErrorResponse(fmt.Sprintf("ERROR: KeyChain: %s", err))
@@ -115,6 +128,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 
 		imgLog.Info("validate: verify signature")
 		if ref, err = name.ParseReference(key); err != nil {
+			allOK = false
 			imgLog.Error("validate: error parsing reference",
 				"error", err)
 			results = append(results, externaldata.Item{
@@ -137,21 +151,32 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		}
 		result, err := p.bf.BundleFromName(fctx, ref, ro)
 		dur := time.Since(start)
-		// Record the fetch latency for both successful and failed fetches.
-		// The tail of this histogram (failed fetches timing out) is a key
-		// signal when troubleshooting registry latency, so it must include
-		// failures.
-		metrics.AttestationsPullTimer.Observe(dur.Seconds())
+		// Label the per-image fetch duration by outcome so success-latency
+		// percentiles and failure durations can be read apart; on failure the
+		// reason/step/attempts dimensions carry the failure taxonomy. The
+		// failure tail (fetches timing out) is a key registry-latency signal,
+		// so it is observed here alongside successes.
+		outcome, reason, step, attempts := "success", "none", "none", 0
+		if err != nil {
+			outcome = "failure"
+			reason, step, attempts = fetcher.Classify(err)
+		} else {
+			attempts = result.Attempts
+		}
+		metrics.AttestationsPullTimer.
+			WithLabelValues(outcome, reason, step, strconv.Itoa(attempts)).
+			Observe(dur.Seconds())
 
 		if err != nil {
-			reason, step, errAttempts := fetcher.Classify(err)
-			metrics.AttestationsRetrieveFail.WithLabelValues(reason).Inc()
+			allOK = false
+			status := strconv.Itoa(fetcher.FailureStatus(err))
+			metrics.AttestationsRetrieveFail.WithLabelValues(reason, step, status).Inc()
 			// The connection-phase fields ride on the existing failure line, so
 			// there is no added log volume on the success path.
 			fields := []any{
 				"reason", reason,
 				"step", step,
-				"attempts", errAttempts,
+				"attempts", attempts,
 				"attempt_trail", fetcher.AttemptTrail(err),
 				"duration_s", dur.Seconds(),
 				"error", err,
@@ -183,6 +208,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		imgLog.Info("validate: fetched OCI bundles", fetchedFields...)
 
 		if len(result.Bundles) == 0 {
+			allOK = false
 			metrics.AttestationsMissing.Inc()
 			imgLog.Info("validate: no bundles")
 			results = append(results, externaldata.Item{
@@ -203,6 +229,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		}
 
 		if err != nil {
+			allOK = false
 			imgLog.Error("validate: verification error",
 				"image_digest", result.Hash.Hex,
 				"error", err)
@@ -218,6 +245,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 				Value: res,
 			})
 		} else {
+			allOK = false
 			imgLog.Info("validate: no valid signatures")
 			results = append(results, externaldata.Item{
 				Key:   key,
@@ -240,4 +268,20 @@ func ErrorResponse(s string) *externaldata.ProviderResponse {
 	resp.Response.SystemError = s
 
 	return &resp
+}
+
+// maxImageCountLabel bounds the request timer's images label. The per-request
+// image count is a handful in practice, but the handler accepts an arbitrary
+// number of keys from the request body, so exact counts are kept only up to
+// this cap and anything larger folds into a single overflow bucket. This keeps
+// the histogram's cardinality finite regardless of request input.
+const maxImageCountLabel = 10
+
+// imageCountLabel renders a request's image count as a bounded label value: the
+// exact count up to maxImageCountLabel, or "<max>+" for anything beyond it.
+func imageCountLabel(n int) string {
+	if n > maxImageCountLabel {
+		return strconv.Itoa(maxImageCountLabel) + "+"
+	}
+	return strconv.Itoa(n)
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
@@ -270,13 +271,30 @@ func (*notFoundBundleFetcher) BundleFromName(_ context.Context, _ name.Reference
 	}
 }
 
+// canceledBundleFetcher fails with a canceled fetch error that carries no
+// registry response (StatusCode 0), exercising the status="0" counter path
+// where the registry never answered.
+type canceledBundleFetcher struct {
+	mockBundleFetcher
+}
+
+func (*canceledBundleFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) (fetcher.BundleResult, error) {
+	return fetcher.BundleResult{Attempts: 3}, &fetcher.FetchError{
+		Step:        fetcher.StepDescriptor,
+		Kind:        fetcher.KindCanceled,
+		Attempts:    3,
+		Recoverable: false,
+		Err:         context.Canceled,
+	}
+}
+
 func TestVerifyNotFound(t *testing.T) {
 	v := &mockVerifier{}
 	kc := &mockKeyChainProvider{}
 	bf := &notFoundBundleFetcher{}
 	provider := New(v, kc, bf)
 
-	before := testutil.ToFloat64(metrics.AttestationsRetrieveFail.WithLabelValues("not_found"))
+	before := testutil.ToFloat64(metrics.AttestationsRetrieveFail.WithLabelValues("not_found", "descriptor", "404"))
 
 	request := &externaldata.ProviderRequest{
 		APIVersion: apiVersion,
@@ -292,38 +310,137 @@ func TestVerifyNotFound(t *testing.T) {
 	assert.Equal(t, "error_fetching_bundle_not_found", response.Response.Items[0].Error)
 	assert.Empty(t, response.Response.SystemError)
 
-	after := testutil.ToFloat64(metrics.AttestationsRetrieveFail.WithLabelValues("not_found"))
-	assert.InDelta(t, 1.0, after-before, 0.0001, `fail metric should be labeled reason="not_found"`)
+	after := testutil.ToFloat64(metrics.AttestationsRetrieveFail.WithLabelValues("not_found", "descriptor", "404"))
+	assert.InDelta(t, 1.0, after-before, 0.0001, `fail metric should be labeled reason="not_found" step="descriptor" status="404"`)
 }
 
-// TestValidateRecordsImageCount verifies the request-images histogram records
-// one observation per request whose value is the number of images (keys).
-func TestValidateRecordsImageCount(t *testing.T) {
-	v := &mockVerifier{}
-	kc := &mockKeyChainProvider{}
-	bf := &mockBundleFetcher{}
-	provider := New(v, kc, bf)
+// TestValidateLabelsFetchFailureCounter verifies the fetch-failure counter is
+// dimensioned by reason, step, and registry status, including the status="0"
+// case where the registry never responded (a cancellation).
+func TestValidateLabelsFetchFailureCounter(t *testing.T) {
+	canceled := metrics.AttestationsRetrieveFail.WithLabelValues("canceled", "descriptor", "0")
+	before := testutil.ToFloat64(canceled)
 
-	readHist := func() (uint64, float64) {
-		m := &dto.Metric{}
-		require.NoError(t, metrics.AttestationsReqImages.Write(m))
-		return m.GetHistogram().GetSampleCount(), m.GetHistogram().GetSampleSum()
-	}
-
-	beforeCount, beforeSum := readHist()
-
-	request := &externaldata.ProviderRequest{
+	provider := New(&mockVerifier{}, &mockKeyChainProvider{}, &canceledBundleFetcher{})
+	provider.Validate(context.Background(), &externaldata.ProviderRequest{
 		APIVersion: apiVersion,
 		Kind:       "ProviderRequest",
-		Request: externaldata.Request{
-			Keys: []string{"image1", "image2", "image3"},
-		},
-	}
-	provider.Validate(context.Background(), request)
+		Request:    externaldata.Request{Keys: []string{validImageName}},
+	})
 
-	afterCount, afterSum := readHist()
-	assert.Equal(t, uint64(1), afterCount-beforeCount, "exactly one request should be observed")
-	assert.InDelta(t, 3.0, afterSum-beforeSum, 0.0001, "sum should increase by the image count")
+	after := testutil.ToFloat64(canceled)
+	assert.InDelta(t, 1.0, after-before, 0.0001,
+		`fail metric should be labeled reason="canceled" step="descriptor" status="0"`)
+}
+
+// errKeyChainProvider always fails to build a keychain, exercising the early
+// request-error return before any image is processed.
+type errKeyChainProvider struct{}
+
+func (*errKeyChainProvider) KeyChain(_ context.Context) (authn.Keychain, error) {
+	return nil, errors.New("keychain boom")
+}
+
+// TestImageCountLabel verifies the request timer's images label is bounded: the
+// exact count up to the cap, and a single overflow bucket beyond it, so an
+// unbounded key count cannot grow histogram cardinality without limit.
+func TestImageCountLabel(t *testing.T) {
+	assert.Equal(t, "0", imageCountLabel(0))
+	assert.Equal(t, "1", imageCountLabel(1))
+	assert.Equal(t, "10", imageCountLabel(maxImageCountLabel))
+	assert.Equal(t, "10+", imageCountLabel(maxImageCountLabel+1))
+	assert.Equal(t, "10+", imageCountLabel(1000))
+}
+
+// observeCount returns the number of observations recorded on a histogram
+// child, read through the concrete metric behind the Observer.
+func observeCount(t *testing.T, o prometheus.Observer) uint64 {
+	t.Helper()
+	m, ok := o.(prometheus.Metric)
+	require.True(t, ok, "histogram child should expose the Metric interface")
+	dtoMetric := &dto.Metric{}
+	require.NoError(t, m.Write(dtoMetric))
+	return dtoMetric.GetHistogram().GetSampleCount()
+}
+
+// TestValidateRecordsFetchOutcome verifies the per-image fetch timer records one
+// observation on the success child on a clean fetch, and one on the matching
+// failure child (carrying reason/step/attempts) when the fetch fails.
+func TestValidateRecordsFetchOutcome(t *testing.T) {
+	fetch := func(bf BundleFetcher) {
+		provider := New(&mockVerifier{}, &mockKeyChainProvider{}, bf)
+		provider.Validate(context.Background(), &externaldata.ProviderRequest{
+			APIVersion: apiVersion,
+			Kind:       "ProviderRequest",
+			Request:    externaldata.Request{Keys: []string{validImageName}},
+		})
+	}
+
+	successChild := metrics.AttestationsPullTimer.WithLabelValues("success", "none", "none", "1")
+	failChild := metrics.AttestationsPullTimer.WithLabelValues("failure", "not_found", "descriptor", "1")
+
+	beforeOK := observeCount(t, successChild)
+	fetch(&mockBundleFetcher{})
+	assert.Equal(t, uint64(1), observeCount(t, successChild)-beforeOK,
+		"a clean fetch should observe the success child once")
+
+	beforeFail := observeCount(t, failChild)
+	fetch(&notFoundBundleFetcher{})
+	assert.Equal(t, uint64(1), observeCount(t, failChild)-beforeFail,
+		"a failed fetch should observe the matching failure child once")
+}
+
+// TestValidateRecordsRequestOutcome verifies the request timer records one
+// observation per request, labelled by the raw image count and whether every
+// image verified cleanly (outcome). This replaces the removed request-images
+// histogram, whose per-request count is now request_timer{images}'s _count.
+func TestValidateRecordsRequestOutcome(t *testing.T) {
+	okVerifier, err := verifier.GHVerifier("")
+	require.NoError(t, err)
+
+	successChild := metrics.AttestationsReqTimer.WithLabelValues("1", "success")
+	failChild := metrics.AttestationsReqTimer.WithLabelValues("1", "failure")
+
+	// A request whose single image verifies cleanly is totally successful.
+	beforeOK := observeCount(t, successChild)
+	provOK := New(okVerifier, &mockKeyChainProvider{}, &mockBundleFetcher{})
+	provOK.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: []string{validImageName}},
+	})
+	assert.Equal(t, uint64(1), observeCount(t, successChild)-beforeOK,
+		"an all-clean request should observe the success child once")
+
+	// A request whose image fails to fetch is not totally successful.
+	beforeFail := observeCount(t, failChild)
+	provFail := New(&mockVerifier{}, &mockKeyChainProvider{}, &notFoundBundleFetcher{})
+	provFail.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: []string{validImageName}},
+	})
+	assert.Equal(t, uint64(1), observeCount(t, failChild)-beforeFail,
+		"a request with a failed image should observe the failure child once")
+}
+
+// TestValidateCountsKeychainErrorRequest verifies the request timer still counts
+// the request (as a failure) when the keychain build fails before any image is
+// processed, so _count covers the early-return path.
+func TestValidateCountsKeychainErrorRequest(t *testing.T) {
+	child := metrics.AttestationsReqTimer.WithLabelValues("2", "failure")
+	before := observeCount(t, child)
+
+	provider := New(&mockVerifier{}, &errKeyChainProvider{}, &mockBundleFetcher{})
+	resp := provider.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: []string{"image1", "image2"}},
+	})
+	require.NotEmpty(t, resp.Response.SystemError, "keychain failure should be a system error")
+
+	assert.Equal(t, uint64(1), observeCount(t, child)-before,
+		"the keychain-error request should be observed once as a failure")
 }
 
 // TestValidateLogsImageContext verifies that per-image log lines carry the


### PR DESCRIPTION
## Summary

Adds low-cost, high-leverage observability to the OCI bundle fetcher so the failure surface can be read directly from metrics instead of reconstructed from raw logs. All label additions are backward-compatible: aggregate queries that don't filter on the new labels are unchanged.

## Changes

- **Failure counter dimensions** — `aaop_attestations_retrieved_fail` gains `step` and `status` alongside the existing `reason`. A nonzero `status` means the registry answered with that HTTP code; `status="0"` means no numeric status was recorded (no response, or a response carrying no numeric status such as a diagnostic-only throttle). Adds a small non-breaking `fetcher.FailureStatus(err)` accessor.
- **Per-image fetch timer** — `aaop_attestations_retrieved_timer` becomes a labelled histogram `{outcome, reason, step, attempts}`, so success-latency percentiles and failure durations can be read apart, with the failure taxonomy carried on failures.
- **Request timer** — `aaop_attestations_request_timer` gains `{images, outcome}` (`outcome` = whether every image verified cleanly). The `images` label is bounded — exact count up to a small cap, with larger counts folded into a `10+` overflow bucket — so an arbitrary request key count can't grow cardinality without limit. Every request is observed once (including the early keychain-error path); the total request count is `sum(aaop_attestations_request_timer_count)` across labels.
- **Histogram buckets** — explicit buckets on the request/fetch timers to resolve the failure tail (the defaults top out at 10s, collapsing everything above into `+Inf`); a small tail added to the keychain build timer.
- **`aaop_config_info` gauge** — standard always-1 info-gauge pattern exposing the effective fetch configuration (`bundle_timeout`, `bundle_max_attempts`, `bundle_delay`, `retry_throttled`), so config drift is visible across instances at a glance.

## Removal (dashboard/monitor migration)

- **Removes `aaop_attestations_request_images`** — made redundant by the `images` label on `request_timer`; the per-request image-count distribution is now `request_timer{images}`'s `_count`. Confirm no dashboard or monitor references `aaop_attestations_request_images` before merging.

## Validation

- `go test ./...` — pass
- `golangci-lint run` — clean
- Hermetic exposition smoke check confirms the new `retrieved_fail{reason,step,status}`, `retrieved_timer{outcome,reason,step,attempts}`, `request_timer{images,outcome}`, and `config_info` series render, and `request_images` is gone.

## Rollout

Source-only change. The new series ship in the next provider image and are picked up on the normal image rollout; no deployment-flag changes are required.
