### PR TITLE
Return a system error when a bundle fetch fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,14 @@ The metrics exposed beyond the default Prometheus metrics are:
   in the request; Gatekeeper sends all of a pod's images in one request, so
   this is the pod's image count — recorded exactly up to a small cap, with
   larger counts folded into a `10+` bucket to keep cardinality bounded) and
-  `outcome` (`success` when every image verified cleanly, otherwise
-  `failure`). Because this is a histogram vector, the total request count is
+  `outcome` (`success` when the provider produced a complete response of
+  per-image verdicts, `failure` when it could not complete the request and
+  returned a system error). Note that an image with a missing or invalid
+  attestation is a `success`: the provider did its job and returned a
+  verdict of "no". Per-image outcomes are counted by
+  `aaop_attestations_missing_total`, `aaop_attestations_verified_fail`, and
+  `aaop_attestations_retrieved_fail`. Because this is a histogram vector,
+  the total request count is
   the sum of the `_count` series across all label values (e.g.
   `sum(aaop_attestations_request_timer_count)`); the `images` label carries
   the per-request image-count distribution (e.g. single-image vs.

--- a/README.md
+++ b/README.md
@@ -250,34 +250,21 @@ The metrics exposed beyond the default Prometheus metrics are:
   `descriptor`, `referrers`, `blob`, or `decode`), and `status` (the
   registry HTTP status code; `0` means no numeric status was recorded —
   the registry never responded, or its response carried no numeric status,
-  such as a diagnostic-only throttle). Apart from `reason="bundle_invalid"`,
-  every increment corresponds to a request the provider aborted with a
-  system error. The invariant holds one way only: not every system error
-  increments this counter.
+  such as a diagnostic-only throttle).
 * `aaop_attestations_verified_ok`: the total number of verified
   attestations.
 * `aaop_attestations_verified_fail`: the total number of
   attestations that failed to verify.
 * `aaop_attestations_request_timer`: the duration in seconds for
   the validation webhook. Labeled by `images` (the number of images/keys
-  in the request; Gatekeeper forwards only the keys it could not serve from
-  its response cache, so this is the request's cache-miss count rather than
-  the pod's image count — a multi-image pod whose entries expire at
-  different times arrives as several separate single-image requests.
-  Recorded exactly up to a small cap, with larger counts folded into a
-  `10+` bucket to keep cardinality bounded) and
+  in the request; Recorded exactly up to a small cap, with larger counts
+  folded into a `10+` bucket to keep cardinality bounded) and
   `outcome` (`success` when the provider produced a complete response of
   per-image verdicts, `failure` when it could not complete the request and
-  returned a system error). Note that an image with a missing or invalid
-  attestation is a `success`: the provider did its job and returned a
-  verdict of "no". Per-image outcomes are counted by
-  `aaop_attestations_missing_total`, `aaop_attestations_verified_fail`, and
-  `aaop_attestations_retrieved_fail`. Because this is a histogram vector,
-  the total request count is
-  the sum of the `_count` series across all label values (e.g.
+  returned a system error). Because this is a histogram vector, the total
+  request count is the sum of the `_count` series across all label values (e.g.
   `sum(aaop_attestations_request_timer_count)`); the `images` label carries
-  the distribution of key counts per request, which is not the same as the
-  distribution of images per pod.
+  the distribution of key counts per request.
 * `aaop_attestations_retrieved_timer`: the duration in seconds to fetch
   the attestations for a single image from the OCI registry, recorded for
   both successful and failed fetches. Labeled by `outcome` (`success` or

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ The metrics exposed beyond the default Prometheus metrics are:
   attestations that failed to verify.
 * `aaop_attestations_request_timer`: the duration in seconds for
   the validation webhook. Labeled by `images` (the number of images/keys
-  in the request; Recorded exactly up to a small cap, with larger counts
+  in the request; recorded exactly up to a small cap, with larger counts
   folded into a `10+` bucket to keep cardinality bounded) and
   `outcome` (`success` when the provider produced a complete response of
   per-image verdicts, `failure` when it could not complete the request and

--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ The metrics exposed beyond the default Prometheus metrics are:
   the total request count is
   the sum of the `_count` series across all label values (e.g.
   `sum(aaop_attestations_request_timer_count)`); the `images` label carries
-  the per-request image-count distribution (e.g. single-image vs.
-  multi-image pods).
+  the distribution of key counts per request, which is not the same as the
+  distribution of images per pod.
 * `aaop_attestations_retrieved_timer`: the duration in seconds to fetch
   the attestations for a single image from the OCI registry, recorded for
   both successful and failed fetches. Labeled by `outcome` (`success` or

--- a/README.md
+++ b/README.md
@@ -250,16 +250,22 @@ The metrics exposed beyond the default Prometheus metrics are:
   `descriptor`, `referrers`, `blob`, or `decode`), and `status` (the
   registry HTTP status code; `0` means no numeric status was recorded —
   the registry never responded, or its response carried no numeric status,
-  such as a diagnostic-only throttle).
+  such as a diagnostic-only throttle). Apart from `reason="bundle_invalid"`,
+  every increment corresponds to a request the provider aborted with a
+  system error. The invariant holds one way only: not every system error
+  increments this counter.
 * `aaop_attestations_verified_ok`: the total number of verified
   attestations.
 * `aaop_attestations_verified_fail`: the total number of
   attestations that failed to verify.
 * `aaop_attestations_request_timer`: the duration in seconds for
   the validation webhook. Labeled by `images` (the number of images/keys
-  in the request; Gatekeeper sends all of a pod's images in one request, so
-  this is the pod's image count — recorded exactly up to a small cap, with
-  larger counts folded into a `10+` bucket to keep cardinality bounded) and
+  in the request; Gatekeeper forwards only the keys it could not serve from
+  its response cache, so this is the request's cache-miss count rather than
+  the pod's image count — a multi-image pod whose entries expire at
+  different times arrives as several separate single-image requests.
+  Recorded exactly up to a small cap, with larger counts folded into a
+  `10+` bucket to keep cardinality bounded) and
   `outcome` (`success` when the provider produced a complete response of
   per-image verdicts, `failure` when it could not complete the request and
   returned a system error). Note that an image with a missing or invalid

--- a/pkg/metrics/prom.go
+++ b/pkg/metrics/prom.go
@@ -64,7 +64,7 @@ var (
 	//nolint: revive
 	AttestationsReqTimer = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "aaop_attestations_request_timer",
-		Help:    "The duration (seconds) for the entire request processing, labelled by image count and outcome (whether every image verified cleanly)",
+		Help:    "The duration (seconds) for the entire request processing, labelled by image count and outcome. success means the provider produced a complete response of per-image verdicts (an image may still be unsigned or unverifiable); failure means the provider could not complete the request and returned a system error",
 		Buckets: requestBuckets,
 	}, []string{"images", "outcome"})
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/uuid"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
@@ -78,23 +78,17 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 	var rstart = time.Now()
 	var err error
 
-	// Record the number of images (keys) in this request. Gatekeeper forwards
-	// only the keys it could not serve from its response cache, so this is the
-	// request's cache-miss count, not the pod's image count: a multi-image pod
-	// whose entries expire at different times arrives as several separate
-	// single-image requests. request_id/image_count/image_index are threaded
+	// Record the number of images (keys) in this request.
+	// request_id/image_count/image_index are threaded
 	// through the per-image logs below so a single failure line (e.g. a fetch
 	// timeout) can be traced back to whether it was a solo or a large
 	// multi-image request.
 	var imageCount = len(r.Request.Keys)
 
 	// systemErr marks a request the provider could not complete: a bundle
-	// fetch failed, or - were either branch reachable - the keychain could not
-	// be built or verification itself errored. It drives the request timer's
-	// outcome, which reports whether the provider processed the request -
-	// deliberately not whether the images turned out to be properly attested.
-	// An unsigned or unverifiable image is a processed request: the provider
-	// did its job and the answer was "no". Declared before the deferred observe
+	// fetch failed. It drives the request timer's outcome, which reports
+	// whether the provider processed the request - NOT whether the images
+	// turned out to be properly attested. Declared before the deferred observe
 	// so the closure captures it, and read only at return.
 	systemErr := false
 	defer func() {
@@ -116,8 +110,6 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 	// Get the keychain to be able to access the OCI registry.
 	// If the keychain configured is empty, the default keychain is used
 	// which works for public registries.
-	// Unreachable today: KeyChainProvider.KeyChain always returns a nil error.
-	// Retained because the interface permits one.
 	if kc, err = p.kc.KeyChain(ctx); err != nil {
 		systemErr = true
 		reqLog.Error("validate: error retrieving key chain",
@@ -195,13 +187,8 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 
 			// A bundle whose layer we read to completion and whose digest was
 			// verified, but which then failed a purely local JSON decode, is a
-			// deterministic snapshot of the artifact: no I/O remains that could
-			// make it flap. Report it per-image so the caller caches the denial
-			// instead of forcing a full fetch-and-decode on every retry.
-			//
-			// Deliberately narrower than "was addressed by digest": blob_error
-			// is also digest-addressed but mixes transport faults with content
-			// faults, so it must not be cached.
+			// deterministic snapshot of the artifact. Report it per-image so
+			// the caller caches the denial.
 			var fe *fetcher.FetchError
 			if errors.As(err, &fe) && fe.Kind == fetcher.KindBundleInvalid {
 				results = append(results, externaldata.Item{
@@ -212,14 +199,12 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 			}
 
 			// Every other fetch failure says nothing durable about the image,
-			// so it must not be reported as a per-image result: callers cache
-			// per-image outcomes and replay them, turning a momentary blip into
-			// a sustained failure. Abort the whole request instead.
+			// so it must not be reported as a per-image result. Abort the
+			// whole request instead.
 			//
-			// This includes 404s. They look like a verdict, but a reference can
-			// be mutable and registries may resolve it only eventually
-			// consistently, so a 404 does not establish that the artifact is
-			// absent.
+			// This includes 404s. A reference can be mutable and registries may
+			// resolve it eventually, so a 404 does not establish that the
+			// artifact is absent.
 			systemErr = true
 			reqLog.Error("validate: aborting request",
 				"reason", reason,
@@ -228,15 +213,12 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 				"images_processed", len(results),
 				"images_skipped", imageCount-(i+1))
 			// Stop here rather than fetching the remaining images: they share
-			// one already-depleted request budget, so they would most likely
-			// fail the same way and delay the response.
+			// one request budget, so they would most likely fail the same way
+			// and delay the response.
 			//
 			// Items completed earlier in this request are still returned. The
 			// caller caches per-image results, so returning them means a retry
-			// re-fetches only what is genuinely missing; the failing image is
-			// omitted precisely so it is NOT cached. Callers are expected to
-			// disregard items while a system error is set, so returning them
-			// cannot be acted on - it only avoids discarding completed work.
+			// re-fetches only what is genuinely missing.
 			resp.Response.Items = results
 			resp.Response.SystemError = fmt.Sprintf(
 				"ERROR: BundleFromName(%q): reason=%s step=%s", key, reason, step)
@@ -278,8 +260,6 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 			metrics.AttestationsVerFail.Add(float64(fail))
 		}
 
-		// Unreachable today: both production Verifier implementations always
-		// return a nil error. Retained because the interface permits one.
 		if err != nil {
 			systemErr = true
 			imgLog.Error("validate: verification error",

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -78,11 +78,14 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 	var rstart = time.Now()
 	var err error
 
-	// Record the number of images (keys) in this request. Gatekeeper sends
-	// every image in a pod as a single request, so this captures the pod's
-	// image count. request_id/image_count/image_index are threaded through the
-	// per-image logs below so a single failure line (e.g. a fetch timeout) can
-	// be traced back to whether it was a solo or a large multi-image request.
+	// Record the number of images (keys) in this request. Gatekeeper forwards
+	// only the keys it could not serve from its response cache, so this is the
+	// request's cache-miss count, not the pod's image count: a multi-image pod
+	// whose entries expire at different times arrives as several separate
+	// single-image requests. request_id/image_count/image_index are threaded
+	// through the per-image logs below so a single failure line (e.g. a fetch
+	// timeout) can be traced back to whether it was a solo or a large
+	// multi-image request.
 	var imageCount = len(r.Request.Keys)
 
 	// systemErr marks a request the provider could not complete: a bundle

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -85,15 +85,18 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 	// be traced back to whether it was a solo or a large multi-image request.
 	var imageCount = len(r.Request.Keys)
 
-	// allOK tracks whether every image in the request verified cleanly. Any
-	// branch below that records an image error (or fails the whole request)
-	// clears it, so the request timer can be split into totally-successful vs
-	// not. It is declared before the deferred observe so the closure captures
-	// it, and read only at return.
-	allOK := true
+	// systemErr marks a request the provider could not complete: a bundle
+	// fetch failed, or - were either branch reachable - the keychain could not
+	// be built or verification itself errored. It drives the request timer's
+	// outcome, which reports whether the provider processed the request -
+	// deliberately not whether the images turned out to be properly attested.
+	// An unsigned or unverifiable image is a processed request: the provider
+	// did its job and the answer was "no". Declared before the deferred observe
+	// so the closure captures it, and read only at return.
+	systemErr := false
 	defer func() {
 		outcome := "success"
-		if !allOK {
+		if systemErr {
 			outcome = "failure"
 		}
 		metrics.AttestationsReqTimer.
@@ -110,8 +113,10 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 	// Get the keychain to be able to access the OCI registry.
 	// If the keychain configured is empty, the default keychain is used
 	// which works for public registries.
+	// Unreachable today: KeyChainProvider.KeyChain always returns a nil error.
+	// Retained because the interface permits one.
 	if kc, err = p.kc.KeyChain(ctx); err != nil {
-		allOK = false
+		systemErr = true
 		reqLog.Error("validate: error retrieving key chain",
 			"error", err)
 		return ErrorResponse(fmt.Sprintf("ERROR: KeyChain: %s", err))
@@ -129,7 +134,6 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 
 		imgLog.Info("validate: verify signature")
 		if ref, err = name.ParseReference(key); err != nil {
-			allOK = false
 			imgLog.Error("validate: error parsing reference",
 				"error", err)
 			results = append(results, externaldata.Item{
@@ -169,7 +173,6 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 			Observe(dur.Seconds())
 
 		if err != nil {
-			allOK = false
 			status := strconv.Itoa(fetcher.FailureStatus(err))
 			metrics.AttestationsRetrieveFail.WithLabelValues(reason, step, status).Inc()
 			// The connection-phase fields ride on the existing failure line, so
@@ -213,6 +216,7 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 			// This includes 404s. They look like a verdict, but tag resolution
 			// is mutable and replicated, and in practice they are dominated by
 			// replication lag that clears in seconds.
+			systemErr = true
 			reqLog.Error("validate: aborting request",
 				"reason", reason,
 				"step", step,
@@ -251,7 +255,6 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		imgLog.Info("validate: fetched OCI bundles", fetchedFields...)
 
 		if len(result.Bundles) == 0 {
-			allOK = false
 			metrics.AttestationsMissing.Inc()
 			imgLog.Info("validate: no bundles")
 			results = append(results, externaldata.Item{
@@ -271,8 +274,10 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 			metrics.AttestationsVerFail.Add(float64(fail))
 		}
 
+		// Unreachable today: both production Verifier implementations always
+		// return a nil error. Retained because the interface permits one.
 		if err != nil {
-			allOK = false
+			systemErr = true
 			imgLog.Error("validate: verification error",
 				"image_digest", result.Hash.Hex,
 				"error", err)
@@ -288,7 +293,6 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 				Value: res,
 			})
 		} else {
-			allOK = false
 			imgLog.Info("validate: no valid signatures")
 			results = append(results, externaldata.Item{
 				Key:   key,

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -254,11 +254,6 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 		res, err = p.v.Verify(result.Bundles, result.Hash)
 		dur = time.Since(start)
 		metrics.AttestationsVerTimer.Observe(dur.Seconds())
-		metrics.AttestationsVerOk.Add(float64(len(res)))
-		var fail = len(result.Bundles) - len(res)
-		if fail > 0 {
-			metrics.AttestationsVerFail.Add(float64(fail))
-		}
 
 		if err != nil {
 			systemErr = true
@@ -266,6 +261,16 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 				"image_digest", result.Hash.Hex,
 				"error", err)
 			return ErrorResponse(fmt.Sprintf("ERROR: VerifyImageSignatures(%q): %v", key, err))
+		}
+
+		// Counted only once the error is ruled out. An erroring Verify returns
+		// no results, so counting first would derive fail from an empty res and
+		// report every bundle as having failed verification when in fact none
+		// was verified at all.
+		metrics.AttestationsVerOk.Add(float64(len(res)))
+		var fail = len(result.Bundles) - len(res)
+		if fail > 0 {
+			metrics.AttestationsVerFail.Add(float64(fail))
 		}
 
 		var bundleVerified = len(res) > 0

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http/httptrace"
@@ -185,11 +186,53 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 				fields = append(fields, tc.Fields()...)
 			}
 			imgLog.Error("validate: error fetching bundles", fields...)
-			results = append(results, externaldata.Item{
-				Key:   key,
-				Error: "error_fetching_bundle_" + reason,
-			})
-			continue
+
+			// A bundle whose layer we read to completion and whose digest was
+			// verified, but which then failed a purely local JSON decode, is a
+			// deterministic snapshot of the artifact: no I/O remains that could
+			// make it flap. Report it per-image so the caller caches the denial
+			// instead of forcing a full fetch-and-decode on every retry.
+			//
+			// Deliberately narrower than "was addressed by digest": blob_error
+			// is also digest-addressed but mixes transport faults with content
+			// faults, so it must not be cached.
+			var fe *fetcher.FetchError
+			if errors.As(err, &fe) && fe.Kind == fetcher.KindBundleInvalid {
+				results = append(results, externaldata.Item{
+					Key:   key,
+					Error: "error_fetching_bundle_" + reason,
+				})
+				continue
+			}
+
+			// Every other fetch failure says nothing durable about the image,
+			// so it must not be reported as a per-image result: callers cache
+			// per-image outcomes and replay them, turning a momentary blip into
+			// a sustained failure. Abort the whole request instead.
+			//
+			// This includes 404s. They look like a verdict, but tag resolution
+			// is mutable and replicated, and in practice they are dominated by
+			// replication lag that clears in seconds.
+			reqLog.Error("validate: aborting request",
+				"reason", reason,
+				"step", step,
+				"image_index", i+1,
+				"images_processed", len(results),
+				"images_skipped", imageCount-(i+1))
+			// Stop here rather than fetching the remaining images: they share
+			// one already-depleted request budget, so they would most likely
+			// fail the same way and delay the response.
+			//
+			// Items completed earlier in this request are still returned. The
+			// caller caches per-image results, so returning them means a retry
+			// re-fetches only what is genuinely missing; the failing image is
+			// omitted precisely so it is NOT cached. Callers are expected to
+			// disregard items while a system error is set, so returning them
+			// cannot be acted on - it only avoids discarding completed work.
+			resp.Response.Items = results
+			resp.Response.SystemError = fmt.Sprintf(
+				"ERROR: BundleFromName(%q): reason=%s step=%s", key, reason, step)
+			return &resp
 		}
 
 		metrics.AttestationsRetrieved.Add(float64(len(result.Bundles)))

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -216,9 +216,10 @@ func (p *Provider) Validate(ctx context.Context, r *externaldata.ProviderRequest
 			// per-image outcomes and replay them, turning a momentary blip into
 			// a sustained failure. Abort the whole request instead.
 			//
-			// This includes 404s. They look like a verdict, but tag resolution
-			// is mutable and replicated, and in practice they are dominated by
-			// replication lag that clears in seconds.
+			// This includes 404s. They look like a verdict, but a reference can
+			// be mutable and registries may resolve it only eventually
+			// consistently, so a 404 does not establish that the artifact is
+			// absent.
 			systemErr = true
 			reqLog.Error("validate: aborting request",
 				"reason", reason,

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/uuid"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	validImageName  = "ghcr.io/github/artifact-attestations-opa-provider:latest"
-	brokenImageName = "ghcr.io/github/artifact-attestations-opa-provider:broken"
+	validImageName    = "ghcr.io/github/artifact-attestations-opa-provider:latest"
+	brokenImageName   = "ghcr.io/github/artifact-attestations-opa-provider:broken"
+	unsignedImageName = "ghcr.io/github/artifact-attestations-opa-provider:unsigned"
 )
 
 var okBundle = `
@@ -600,6 +601,59 @@ func TestValidateRecordsRequestOutcome(t *testing.T) {
 	})
 	assert.Equal(t, uint64(1), observeCount(t, failChild)-beforeFail,
 		"a request with a failed image should observe the failure child once")
+}
+
+// TestValidateRequestOutcomeReportsProcessing verifies the request timer's
+// outcome reports whether the provider completed the request, not whether the
+// images were properly attested. Every per-image verdict branch is covered, so
+// each deleted allOK assignment is pinned by an assertion.
+func TestValidateRequestOutcomeReportsProcessing(t *testing.T) {
+	successChild := metrics.AttestationsReqTimer.WithLabelValues("1", "success")
+	failChild := metrics.AttestationsReqTimer.WithLabelValues("1", "failure")
+
+	// Each of these is a verdict about the image, so the request WAS processed.
+	verdicts := []struct {
+		name    string
+		key     string
+		verify  Verifier
+		fetcher BundleFetcher
+	}{
+		// name.ParseReference fails -> invalid_reference (provider.go:131)
+		{"invalid_reference", "foo+bar", &mockVerifier{}, &mockBundleFetcher{}},
+		// fetch succeeds with zero bundles -> image_unsigned (provider.go:211)
+		{"image_unsigned", unsignedImageName, &mockVerifier{}, &mockBundleFetcher{}},
+		// bundles fetched, none verify -> invalid_signature (provider.go:248)
+		{"invalid_signature", validImageName, &mockVerifier{}, &mockBundleFetcher{}},
+		// decoded-by-digest failure -> error_fetching_bundle_bundle_invalid
+		{"bundle_invalid", validImageName, &mockVerifier{}, &bundleInvalidFetcher{}},
+	}
+
+	for _, tc := range verdicts {
+		t.Run(tc.name, func(t *testing.T) {
+			before := observeCount(t, successChild)
+			p := New(tc.verify, &mockKeyChainProvider{}, tc.fetcher)
+			p.Validate(context.Background(), &externaldata.ProviderRequest{
+				APIVersion: apiVersion,
+				Kind:       "ProviderRequest",
+				Request:    externaldata.Request{Keys: []string{tc.key}},
+			})
+			assert.Equal(t, uint64(1), observeCount(t, successChild)-before,
+				"a per-image verdict is a processed request, not a provider failure")
+		})
+	}
+
+	// A fetch failure aborts the request: the provider could not complete it.
+	t.Run("fetch failure", func(t *testing.T) {
+		beforeFail := observeCount(t, failChild)
+		provAbort := New(&mockVerifier{}, &mockKeyChainProvider{}, &timeoutBundleFetcher{})
+		provAbort.Validate(context.Background(), &externaldata.ProviderRequest{
+			APIVersion: apiVersion,
+			Kind:       "ProviderRequest",
+			Request:    externaldata.Request{Keys: []string{validImageName}},
+		})
+		assert.Equal(t, uint64(1), observeCount(t, failChild)-beforeFail,
+			"an aborted request should observe the failure child once")
+	})
 }
 
 // TestValidateCountsKeychainErrorRequest verifies the request timer still counts

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -561,6 +561,16 @@ func (*errKeyChainProvider) KeyChain(_ context.Context) (authn.Keychain, error) 
 	return nil, errors.New("keychain boom")
 }
 
+// errVerifier reports that verification could not be performed, returning no
+// results alongside the error as a Go implementation conventionally would. No
+// production Verifier does this today, but the interface permits it and the
+// provider must not mistake it for a verdict about the attestations.
+type errVerifier struct{}
+
+func (*errVerifier) Verify(_ []*bundle.Bundle, _ *v1.Hash) ([]*verify.VerificationResult, error) {
+	return nil, errors.New("verify boom")
+}
+
 // TestImageCountLabel verifies the request timer's images label is bounded: the
 // exact count up to the cap, and a single overflow bucket beyond it, so an
 // unbounded key count cannot grow histogram cardinality without limit.
@@ -716,6 +726,34 @@ func TestValidateCountsKeychainErrorRequest(t *testing.T) {
 
 	assert.Equal(t, uint64(1), observeCount(t, child)-before,
 		"the keychain-error request should be observed once as a failure")
+}
+
+// TestValidateSkipsVerdictCountersWhenVerificationErrors pins the ordering of
+// the verification counters against the error check. When Verify returns an
+// error it returns no results, so recording verdicts first would compute
+// fail = len(bundles) - 0 and attribute a failed verification to every bundle
+// in the request - reporting a fault that stopped verification from running as
+// attestations that were checked and rejected. That is the same mistake this
+// provider avoids on the fetch path, one layer down.
+func TestValidateSkipsVerdictCountersWhenVerificationErrors(t *testing.T) {
+	beforeOK := testutil.ToFloat64(metrics.AttestationsVerOk)
+	beforeFail := testutil.ToFloat64(metrics.AttestationsVerFail)
+
+	// mockBundleFetcher returns one bundle for validImageName, so a
+	// count-before-check would record exactly one bogus failure.
+	provider := New(&errVerifier{}, &mockKeyChainProvider{}, &mockBundleFetcher{})
+	resp := provider.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: []string{validImageName}},
+	})
+	require.NotEmpty(t, resp.Response.SystemError,
+		"a verification error should be a system error")
+
+	assert.InDelta(t, 0.0, testutil.ToFloat64(metrics.AttestationsVerFail)-beforeFail, 0.0001,
+		"a verification that could not run must not count any bundle as failed")
+	assert.InDelta(t, 0.0, testutil.ToFloat64(metrics.AttestationsVerOk)-beforeOK, 0.0001,
+		"nor as verified")
 }
 
 // TestValidateLogsImageContext verifies that per-image log lines carry the

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -230,10 +230,6 @@ func TestInvalid(t *testing.T) {
 			image: "foo+bar",
 			error: "invalid_reference",
 		},
-		{
-			image: brokenImageName,
-			error: "error_fetching_bundle_unknown",
-		},
 	}
 
 	for _, tc := range tests {
@@ -252,6 +248,32 @@ func TestInvalid(t *testing.T) {
 		assert.Len(t, response.Response.Items, 1)
 		assert.Equal(t, tc.error, response.Response.Items[0].Error)
 	}
+}
+
+// TestInvalidBundleAbortsRequest covers the case lifted out of TestInvalid's
+// table. mockBundleFetcher fails brokenImageName with a raw json error, which
+// classifies as "unknown" rather than bundle_invalid, so it is a fetch failure
+// that aborts the request instead of becoming a cached item error. This test
+// never covered the bundle_invalid path; that is pinned by
+// TestValidateKeepsBundleInvalidAsItemError.
+func TestInvalidBundleAbortsRequest(t *testing.T) {
+	v, err := verifier.GHVerifier("")
+	require.NoError(t, err)
+	provider := New(v, &mockKeyChainProvider{}, &mockBundleFetcher{})
+
+	response := provider.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{brokenImageName},
+		},
+	})
+
+	require.NotNil(t, response)
+	assert.NotEmpty(t, response.Response.SystemError,
+		"an unclassified fetch failure must abort the request")
+	assert.Empty(t, response.Response.Items,
+		"no item may be returned, or the caller will cache the failure")
 }
 
 // notFoundBundleFetcher always fails with a 404 (MANIFEST_UNKNOWN) fetch
@@ -288,30 +310,184 @@ func (*canceledBundleFetcher) BundleFromName(_ context.Context, _ name.Reference
 	}
 }
 
-func TestVerifyNotFound(t *testing.T) {
-	v := &mockVerifier{}
-	kc := &mockKeyChainProvider{}
-	bf := &notFoundBundleFetcher{}
-	provider := New(v, kc, bf)
+// oneResultVerifier reports one successful verification, so an image whose
+// fetch succeeds produces a clean item. mockVerifier returns (nil, nil), which
+// with mockBundleFetcher's single bundle yields invalid_signature and would
+// defeat the retain assertions.
+type oneResultVerifier struct{}
 
-	before := testutil.ToFloat64(metrics.AttestationsRetrieveFail.WithLabelValues("not_found", "descriptor", "404"))
+func (*oneResultVerifier) Verify(_ []*bundle.Bundle, _ *v1.Hash) ([]*verify.VerificationResult, error) {
+	return []*verify.VerificationResult{{
+		MediaType: "application/vnd.dev.sigstore.verificationresult+json;version=0.1",
+	}}, nil
+}
 
-	request := &externaldata.ProviderRequest{
+// timeoutBundleFetcher fails with a timeout that carries no registry response.
+type timeoutBundleFetcher struct {
+	mockBundleFetcher
+	calls int
+}
+
+func (f *timeoutBundleFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) (fetcher.BundleResult, error) {
+	f.calls++
+	return fetcher.BundleResult{Attempts: 3}, &fetcher.FetchError{
+		Step:        fetcher.StepReferrers,
+		Kind:        fetcher.KindTimeout,
+		Attempts:    3,
+		Recoverable: true,
+		Err:         errors.New("timeout awaiting response headers"),
+	}
+}
+
+// okThenTimeoutFetcher succeeds on the first image and then fails, exercising
+// the retain-verified-items path.
+type okThenTimeoutFetcher struct {
+	mockBundleFetcher
+	calls int
+}
+
+func (f *okThenTimeoutFetcher) BundleFromName(ctx context.Context, ref name.Reference, ro []remote.Option) (fetcher.BundleResult, error) {
+	f.calls++
+	if f.calls == 1 {
+		return f.mockBundleFetcher.BundleFromName(ctx, ref, ro)
+	}
+	return fetcher.BundleResult{Attempts: 3}, &fetcher.FetchError{
+		Step:        fetcher.StepReferrers,
+		Kind:        fetcher.KindTimeout,
+		Attempts:    3,
+		Recoverable: true,
+		Err:         errors.New("timeout awaiting response headers"),
+	}
+}
+
+// TestValidateReturnsSystemErrorOnFetchFailure verifies that a fetch failure
+// aborts the request with a system error and no items, so the caller has
+// nothing cacheable to replay.
+func TestValidateReturnsSystemErrorOnFetchFailure(t *testing.T) {
+	provider := New(&mockVerifier{}, &mockKeyChainProvider{}, &timeoutBundleFetcher{})
+
+	resp := provider.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: []string{validImageName}},
+	})
+
+	assert.NotEmpty(t, resp.Response.SystemError,
+		"a fetch failure must surface as a system error")
+	assert.Empty(t, resp.Response.Items,
+		"no items may be returned, or the caller will cache the failure")
+	assert.Contains(t, resp.Response.SystemError, "timeout")
+	assert.Contains(t, resp.Response.SystemError, "referrers")
+}
+
+// TestValidateAbortsRemainingImages verifies fail-fast: once the request is
+// known to return a system error, later images are not fetched at all.
+func TestValidateAbortsRemainingImages(t *testing.T) {
+	bf := &timeoutBundleFetcher{}
+	provider := New(&mockVerifier{}, &mockKeyChainProvider{}, bf)
+
+	provider.Validate(context.Background(), &externaldata.ProviderRequest{
 		APIVersion: apiVersion,
 		Kind:       "ProviderRequest",
 		Request: externaldata.Request{
-			Keys: []string{validImageName},
+			Keys: []string{validImageName, brokenImageName, validImageName},
 		},
+	})
+
+	assert.Equal(t, 1, bf.calls,
+		"the request must abort on the first fetch failure, not fetch the remaining images")
+}
+
+// TestValidateRetainsVerifiedItemsOnAbort verifies that images verified before
+// the abort are still returned. They are cacheable by the caller, so a retry
+// re-fetches only the images that are genuinely missing.
+func TestValidateRetainsVerifiedItemsOnAbort(t *testing.T) {
+	okThenTimeout := &okThenTimeoutFetcher{}
+	provider := New(&oneResultVerifier{}, &mockKeyChainProvider{}, okThenTimeout)
+
+	resp := provider.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: []string{validImageName, brokenImageName}},
+	})
+
+	assert.NotEmpty(t, resp.Response.SystemError)
+	require.Len(t, resp.Response.Items, 1,
+		"the image verified before the abort should still be returned")
+	assert.Equal(t, validImageName, resp.Response.Items[0].Key)
+	assert.Empty(t, resp.Response.Items[0].Error,
+		"the retained item is a clean result, not the failure")
+}
+
+// TestValidateAbortsOnNotFound pins the decision that a 404 is NOT treated as a
+// cacheable per-image verdict. Fleet data shows these are overwhelmingly
+// registry replication lag that clears in seconds, so caching the denial would
+// outlive its cause. It also pins that the failure counter still increments
+// before the abort, which the operational runbook depends on.
+func TestValidateAbortsOnNotFound(t *testing.T) {
+	failCounter := metrics.AttestationsRetrieveFail.WithLabelValues("not_found", "descriptor", "404")
+	before := testutil.ToFloat64(failCounter)
+
+	provider := New(&mockVerifier{}, &mockKeyChainProvider{}, &notFoundBundleFetcher{})
+
+	resp := provider.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: []string{validImageName}},
+	})
+
+	assert.NotEmpty(t, resp.Response.SystemError,
+		"a 404 must abort, not become a cached item error")
+	assert.Empty(t, resp.Response.Items)
+
+	after := testutil.ToFloat64(failCounter)
+	assert.InDelta(t, 1.0, after-before, 0.0001,
+		"the fetch-failure counter must still increment before the abort")
+}
+
+// bundleInvalidFetcher fails with a decode error on a blob that was fetched
+// successfully by digest.
+type bundleInvalidFetcher struct {
+	mockBundleFetcher
+}
+
+func (*bundleInvalidFetcher) BundleFromName(_ context.Context, _ name.Reference, _ []remote.Option) (fetcher.BundleResult, error) {
+	// Attempts must be set on the FetchError, not just on the BundleResult:
+	// Classify reads it from the error (bundle.go:637-648), so omitting it
+	// emits a misleading attempts="0" label.
+	return fetcher.BundleResult{Attempts: 1}, &fetcher.FetchError{
+		Step:        fetcher.StepDecode,
+		Kind:        fetcher.KindBundleInvalid,
+		Attempts:    1,
+		Recoverable: false,
+		Err:         errors.New("invalid character 'x' looking for beginning of value"),
 	}
+}
 
-	response := provider.Validate(context.Background(), request)
-	require.NotNil(t, response)
-	assert.Len(t, response.Response.Items, 1)
-	assert.Equal(t, "error_fetching_bundle_not_found", response.Response.Items[0].Error)
-	assert.Empty(t, response.Response.SystemError)
+// TestValidateKeepsBundleInvalidAsItemError pins the single exception: the
+// layer was read to completion and digest-verified, and only the local JSON
+// decode failed, so no I/O remains that could make the outcome flap within a
+// cache TTL. Caching it is correct, and NOT caching it would force a full
+// fetch-and-decode on every controller retry.
+//
+// This is deliberately narrower than "was addressed by digest" - blob_error is
+// also digest-addressed but mixes transport with content faults.
+//
+// Note this cannot be exercised through mockBundleFetcher's brokenImageName,
+// which returns a raw json error that classifies as "unknown".
+func TestValidateKeepsBundleInvalidAsItemError(t *testing.T) {
+	provider := New(&mockVerifier{}, &mockKeyChainProvider{}, &bundleInvalidFetcher{})
 
-	after := testutil.ToFloat64(metrics.AttestationsRetrieveFail.WithLabelValues("not_found", "descriptor", "404"))
-	assert.InDelta(t, 1.0, after-before, 0.0001, `fail metric should be labeled reason="not_found" step="descriptor" status="404"`)
+	resp := provider.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request:    externaldata.Request{Keys: []string{validImageName}},
+	})
+
+	assert.Empty(t, resp.Response.SystemError,
+		"a completed, digest-verified decode failure is a verdict, not a provider fault")
+	require.Len(t, resp.Response.Items, 1)
+	assert.Equal(t, "error_fetching_bundle_bundle_invalid", resp.Response.Items[0].Error)
 }
 
 // TestValidateLabelsFetchFailureCounter verifies the fetch-failure counter is
@@ -413,6 +589,8 @@ func TestValidateRecordsRequestOutcome(t *testing.T) {
 		"an all-clean request should observe the success child once")
 
 	// A request whose image fails to fetch is not totally successful.
+	// The label survived a meaning change: the 404 now lands on "failure"
+	// because it returns a system error rather than a per-image item error.
 	beforeFail := observeCount(t, failChild)
 	provFail := New(&mockVerifier{}, &mockKeyChainProvider{}, &notFoundBundleFetcher{})
 	provFail.Validate(context.Background(), &externaldata.ProviderRequest{
@@ -489,9 +667,11 @@ func TestValidateLogsImageContext(t *testing.T) {
 	assert.NotEmpty(t, entry["request_id"])
 
 	assert.InDelta(t, 2.0, fetchErr["image_count"], 0.0001, "failure line should report the request image count")
-	// fetchErr is the last "error fetching bundles" line, i.e. the second
-	// image, so its 1-based image_index must be 2.
-	assert.InDelta(t, 2.0, fetchErr["image_index"], 0.0001, "failure line should report the 1-based image position")
+	// The first image's fetch fails, which aborts the request before the
+	// second image is ever fetched, so there is exactly one failure line and
+	// its 1-based image_index must be 1. image_count stays 2: the request
+	// really did carry two keys.
+	assert.InDelta(t, 1.0, fetchErr["image_index"], 0.0001, "failure line should report the 1-based image position")
 	assert.InDelta(t, 1.0, fetchErr["attempts"], 0.0001, "failure line should report the fetch attempt count")
 	assert.Equal(t, entry["request_id"], fetchErr["request_id"],
 		"per-image failure line should carry the request's correlation id")

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -251,13 +251,14 @@ func TestInvalid(t *testing.T) {
 	}
 }
 
-// TestInvalidBundleAbortsRequest covers the case lifted out of TestInvalid's
-// table. mockBundleFetcher fails brokenImageName with a raw json error, which
-// classifies as "unknown" rather than bundle_invalid, so it is a fetch failure
-// that aborts the request instead of becoming a cached item error. This test
-// never covered the bundle_invalid path; that is pinned by
+// TestUnclassifiedFetchErrorAbortsRequest covers the case lifted out of
+// TestInvalid's table. mockBundleFetcher fails brokenImageName with a raw json
+// error, which classifies as "unknown" rather than bundle_invalid, so it is an
+// ordinary fetch failure that aborts the request rather than the cached
+// per-image exception. Despite the fixture's name, this does NOT exercise the
+// bundle_invalid path; that is pinned by
 // TestValidateKeepsBundleInvalidAsItemError.
-func TestInvalidBundleAbortsRequest(t *testing.T) {
+func TestUnclassifiedFetchErrorAbortsRequest(t *testing.T) {
 	v, err := verifier.GHVerifier("")
 	require.NoError(t, err)
 	provider := New(v, &mockKeyChainProvider{}, &mockBundleFetcher{})
@@ -399,6 +400,47 @@ func TestValidateAbortsRemainingImages(t *testing.T) {
 		"the request must abort on the first fetch failure, not fetch the remaining images")
 }
 
+// TestValidateLogsAbortContext verifies the request-level abort line and its
+// fields, which are the operational signal that a request was not completed.
+//
+// The keys are chosen so images_processed is non-zero and its contents are an
+// error item, pinning that it counts every item appended so far - including
+// per-image error verdicts - and is not a count of clean verifications.
+func TestValidateLogsAbortContext(t *testing.T) {
+	provider := New(&mockVerifier{}, &mockKeyChainProvider{}, &timeoutBundleFetcher{})
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	// "foo+bar" is unparseable, so it appends an invalid_reference item without
+	// fetching. The second key then fails to fetch and aborts, leaving the
+	// third key untouched.
+	provider.Validate(context.Background(), &externaldata.ProviderRequest{
+		APIVersion: apiVersion,
+		Kind:       "ProviderRequest",
+		Request: externaldata.Request{
+			Keys: []string{"foo+bar", validImageName, brokenImageName},
+		},
+	})
+
+	abort := lastLogLine(t, &buf, "validate: aborting request")
+	require.NotNil(t, abort, "an aborted request must log a request-level abort line")
+
+	assert.Equal(t, "timeout", abort["reason"])
+	assert.Equal(t, "referrers", abort["step"])
+	// JSON numbers decode as float64.
+	assert.InDelta(t, 2.0, abort["image_index"], 0.0001,
+		"the abort should report the 1-based position of the failing image")
+	assert.InDelta(t, 1.0, abort["images_processed"], 0.0001,
+		"images_processed counts every item appended so far, including error items")
+	assert.InDelta(t, 1.0, abort["images_skipped"], 0.0001,
+		"the images after the failure are skipped, not fetched")
+	assert.NotEmpty(t, abort["request_id"],
+		"the abort line should carry the request's correlation id")
+}
+
 // TestValidateRetainsVerifiedItemsOnAbort verifies that images verified before
 // the abort are still returned. They are cacheable by the caller, so a retry
 // re-fetches only the images that are genuinely missing.
@@ -421,10 +463,11 @@ func TestValidateRetainsVerifiedItemsOnAbort(t *testing.T) {
 }
 
 // TestValidateAbortsOnNotFound pins the decision that a 404 is NOT treated as a
-// cacheable per-image verdict. Fleet data shows these are overwhelmingly
-// registry replication lag that clears in seconds, so caching the denial would
-// outlive its cause. It also pins that the failure counter still increments
-// before the abort, which the operational runbook depends on.
+// cacheable per-image verdict. A reference can be mutable and a registry may
+// resolve it only eventually consistently, so a 404 does not establish that the
+// artifact is absent and caching the denial could outlive its cause. It also
+// pins that the failure counter still increments before the abort, so the
+// failure taxonomy survives the change.
 func TestValidateAbortsOnNotFound(t *testing.T) {
 	failCounter := metrics.AttestationsRetrieveFail.WithLabelValues("not_found", "descriptor", "404")
 	before := testutil.ToFloat64(failCounter)


### PR DESCRIPTION
## The problem

A registry fetch failure is currently reported as a per-image `Error` on the response item. That is the wrong shape for the information we actually have.

Gatekeeper's external-data driver caches every item it receives for the full response-cache TTL, errors included — there is no `if item.Error == ""` guard on the cache path. So a per-image error is not a one-off answer; it is a verdict the caller will replay unchanged for the whole TTL without calling the provider again. 

The question we should ask for each failure is "do we want this response cached?"

For a fetch failure the answer is no. A timeout, cancellation, throttle, or unavailable referrers response describes the path to the registry at that instant. A 401 or 403 describes our own credentials, which the background keychain refresh repairs. A 404 looks durable but is not: tag resolution is mutable and replicated, so it is dominated by replication lag that clears in seconds. None of these are properties of the artifact, and caching any of them turns a momentary blip into a sustained failure.


## The fix

A fetch failure now returns a `systemError` and aborts the request rather than appending an item.

The request also fails fast: once the response is known to carry a system error, the remaining images are not fetched. They share one already-depleted request budget, so they would most likely fail the same way and only delay the response. 

Images already processed earlier in the request are still returned alongside the system error. The caller caches per-image results, so retaining them means a retry re-fetches only what is genuinely missing; the failing image is omitted precisely so it is *not* cached. Consumers are expected to disregard items while a system error is set, so the retained items cannot be acted on — they only avoid discarding completed work.

## The one exception: `bundle_invalid`

A bundle that was retrieved and then failed to decode stays a per-image item error.

Not caching `bundle_invalid` would also be actively harmful: a malformed bundle would force a full descriptor, referrers, and blob fetch and decode on every controller retry, indefinitely. Registry content is publisher-supplied, so that is an amplification path an attacker with push access could aim at the provider.

## Metric interface change

`aaop_attestations_request_timer{outcome}` changes meaning. It was derived from "did every image verify cleanly", which conflated provider health with the attestation state of the images. An image with a missing or invalid attestation is a *successfully processed* request — the provider fetched, verified, and returned a correct verdict of "no".

`outcome` now reports whether the provider produced a complete response: `failure` means it returned a system error. Per-image outcomes remain available on `aaop_attestations_missing_total`, `aaop_attestations_verified_fail`, and `aaop_attestations_retrieved_fail`. 

## ⚠️ Required before deploying to an enforcing cluster

**Merging this is safe; deploying it is gated on a consuming-policy change.**

Before pointing any *enforcing* cluster at a build containing this change, confirm the policy denies on `system_error`, and verify it against both response shapes the provider can now produce: a system error with empty `responses` and `errors`, and a system error alongside a non-empty `responses` array carrying retained items. 



## Testing

`go test ./... -race` and `golangci-lint run` are both clean.

New coverage: a fetch failure returns a system error with no items; the request aborts without fetching remaining images; items verified before the abort are retained; a 404 aborts and still increments the failure counter; `bundle_invalid` stays a per-image item error; the request-timer `outcome` reports `success` for every per-image verdict branch (`invalid_reference`, `image_unsigned`, `invalid_signature`, `bundle_invalid`) and `failure` only on abort; and a verification error records neither a verified nor a failed attestation.
