### PR TITLE
Fix last_conn_idle_ms to use the not-recorded sentinel

### DIFF
--- a/pkg/fetcher/trace.go
+++ b/pkg/fetcher/trace.go
@@ -37,12 +37,15 @@ type TraceCollector struct {
 
 	// Most-recent-connection fields, reset per request at GetConn.
 	lastReused bool
-	lastIdle   time.Duration
-	dns        time.Duration
-	connect    time.Duration
-	tls        time.Duration
-	ttfb       time.Duration // GotConn to first response byte; -1 if never.
-	wroteReq   bool
+	// lastIdle is only meaningful when lastReused is true; otherwise it holds
+	// durationUnset, since a connection that was never reused has no idle
+	// time to report.
+	lastIdle time.Duration
+	dns      time.Duration
+	connect  time.Duration
+	tls      time.Duration
+	ttfb     time.Duration // GotConn to first response byte; -1 if never.
+	wroteReq bool
 
 	// Transient phase-start timestamps.
 	dnsStart  time.Time
@@ -58,10 +61,11 @@ type TraceCollector struct {
 // millisecond.
 func NewTraceCollector() *TraceCollector {
 	return &TraceCollector{
-		dns:     durationUnset,
-		connect: durationUnset,
-		tls:     durationUnset,
-		ttfb:    durationUnset,
+		dns:      durationUnset,
+		connect:  durationUnset,
+		tls:      durationUnset,
+		ttfb:     durationUnset,
+		lastIdle: durationUnset,
 	}
 }
 
@@ -83,7 +87,7 @@ func (c *TraceCollector) Trace() *httptrace.ClientTrace {
 			c.tls = durationUnset
 			c.wroteReq = false
 			c.lastReused = false
-			c.lastIdle = 0
+			c.lastIdle = durationUnset
 			c.gotConnAt = time.Time{}
 			c.mu.Unlock()
 		},
@@ -180,7 +184,7 @@ func (c *TraceCollector) Fields() []any {
 		"conns_reused", c.reusedConns,
 		"conns_new", c.newConns,
 		"last_conn_reused", c.lastReused,
-		"last_conn_idle_ms", c.lastIdle.Milliseconds(),
+		"last_conn_idle_ms", ms(c.lastIdle),
 		"dns_ms", ms(c.dns),
 		"connect_ms", ms(c.connect),
 		"tls_ms", ms(c.tls),

--- a/pkg/fetcher/trace_test.go
+++ b/pkg/fetcher/trace_test.go
@@ -76,6 +76,50 @@ func TestTraceCollectorReusedConnectionNeverReturnsFirstByte(t *testing.T) {
 	assert.Equal(t, int64(-1), asInt64(t, f["tls_ms"]))
 }
 
+// TestTraceCollectorLastConnIdleMsUnobserved verifies that last_conn_idle_ms
+// reports the notRecorded sentinel, not 0, whenever an idle time was never
+// observed: a fresh collector that instrumented no request at all, and a
+// fresh (non-reused) dial, which never assigns an idle time because that
+// assignment only happens on the httptrace.GotConnInfo.Reused branch.
+func TestTraceCollectorLastConnIdleMsUnobserved(t *testing.T) {
+	t.Run("fresh collector, no requests", func(t *testing.T) {
+		c := NewTraceCollector()
+
+		f := fieldMap(t, c.Fields())
+		assert.Equal(t, int64(-1), asInt64(t, f["last_conn_idle_ms"]))
+	})
+
+	t.Run("fresh dial", func(t *testing.T) {
+		c := NewTraceCollector()
+		tr := c.Trace()
+
+		tr.GetConn("registry.example:443")
+		tr.GotConn(httptrace.GotConnInfo{Reused: false})
+
+		f := fieldMap(t, c.Fields())
+		assert.Equal(t, false, f["last_conn_reused"])
+		assert.Equal(t, int64(-1), asInt64(t, f["last_conn_idle_ms"]))
+	})
+}
+
+// TestTraceCollectorLastConnIdleMsGenuineZero verifies that a reused
+// connection with a sub-millisecond idle time reports a genuine 0, which must
+// stay distinct from the -1 sentinel reported when no idle time was observed
+// at all (TestTraceCollectorLastConnIdleMsUnobserved). This is the regression
+// case for the fix: routing last_conn_idle_ms through the same ms() sentinel
+// helper as the other phase timings must not turn this genuine 0 into -1.
+func TestTraceCollectorLastConnIdleMsGenuineZero(t *testing.T) {
+	c := NewTraceCollector()
+	tr := c.Trace()
+
+	tr.GetConn("registry.example:443")
+	tr.GotConn(httptrace.GotConnInfo{Reused: true, IdleTime: 0})
+
+	f := fieldMap(t, c.Fields())
+	assert.Equal(t, true, f["last_conn_reused"])
+	assert.Equal(t, int64(0), asInt64(t, f["last_conn_idle_ms"]))
+}
+
 // TestTraceCollectorClearsPriorConnectionOnNewRequest verifies that a request
 // which fails during establishment (GetConn but no GotConn) does not inherit
 // the previous request's reuse state, so the failure line cannot claim a
@@ -96,7 +140,8 @@ func TestTraceCollectorClearsPriorConnectionOnNewRequest(t *testing.T) {
 	f := fieldMap(t, c.Fields())
 	assert.Equal(t, false, f["last_conn_reused"],
 		"stale reuse state from the prior request must be cleared at GetConn")
-	assert.Equal(t, int64(0), asInt64(t, f["last_conn_idle_ms"]))
+	assert.Equal(t, int64(-1), asInt64(t, f["last_conn_idle_ms"]),
+		"stale idle time from the prior request must be cleared at GetConn, not reported as a genuine 0")
 	assert.Equal(t, int64(-1), asInt64(t, f["ttfb_ms"]),
 		"a request that never received a byte must not inherit the prior ttfb")
 	// The fetch-level reuse count still reflects the first, completed request.
@@ -177,6 +222,7 @@ func TestTraceCollectorInstrumentsRealRequest(t *testing.T) {
 	assert.Equal(t, 1, asInt(t, f["conns_new"]))
 	assert.Equal(t, 0, asInt(t, f["conns_reused"]))
 	assert.Equal(t, false, f["last_conn_reused"])
+	assert.Equal(t, int64(-1), asInt64(t, f["last_conn_idle_ms"]))
 	// connect_ms and tls_ms are sub-millisecond on loopback, so only their
 	// presence and non-negativity are asserted here; the synthetic fresh-dial
 	// test above exercises their timing exactly.
@@ -217,4 +263,5 @@ func TestTraceCollectorReportsBlackHoleOnRealRequest(t *testing.T) {
 	f := fieldMap(t, c.Fields())
 	assert.Equal(t, true, f["wrote_request"])
 	assert.Equal(t, int64(-1), asInt64(t, f["ttfb_ms"]))
+	assert.Equal(t, int64(-1), asInt64(t, f["last_conn_idle_ms"]))
 }


### PR DESCRIPTION
## Context

`pkg/fetcher`'s `TraceCollector` attaches an `httptrace.ClientTrace` to each bundle-fetch request and, when a fetch fails, logs a set of connection-phase timings alongside the failure reason: DNS lookup time, TCP connect time, TLS handshake time, whether the connection was reused from the pool versus freshly dialed, how long a reused connection had been idle, whether the request was ever written, and time-to-first-byte. The goal (added in #214) is to tell, from the log line alone, which stage of the connection lifecycle a stalled or failed fetch got stuck in, rather than having to guess.

A fetch can land on a pooled (reused) connection just as easily as a fresh one, and several of these fields are legitimately skipped depending on which happens — DNS, connect, and TLS never run at all when an existing connection is reused, for example. So that "this phase never ran" stays distinguishable from "this phase ran in under a millisecond," `TraceCollector.Fields()` reports every unobserved phase as `-1` rather than `0`. That's what the `notRecorded` sentinel and the `ms()` helper in `trace.go` exist for.

## The bug

`last_conn_idle_ms` — how long a *reused* connection had been sitting idle in the pool before this request picked it up — doesn't follow that convention. It's emitted as a raw `c.lastIdle.Milliseconds()` instead of being routed through `ms()`, and the underlying `lastIdle` field defaults to its zero value instead of starting at the unset sentinel. The result: a connection whose idle time was never observed at all — because no connection was ever acquired, or because the connection was freshly dialed rather than reused — reports `last_conn_idle_ms=0`, which is exactly the value a reused connection with a genuinely negligible idle time would also report. The field is only meaningful when `last_conn_reused=true`, but nothing in the output says so, so the ambiguous `0` shows up regardless of which case produced it.

## The fix

Three one-line changes in `pkg/fetcher/trace.go` bring `last_conn_idle_ms` in line with the other phase timings:

1. `NewTraceCollector()` now initializes `lastIdle` to the unset sentinel, matching `dns`/`connect`/`tls`/`ttfb`.
2. The per-request reset in `GetConn` resets `lastIdle` to the unset sentinel instead of `0`.
3. `Fields()` routes `lastIdle` through `ms()` instead of calling `.Milliseconds()` on it directly.

Both changes are necessary together, which is worth calling out since each looks sufficient on its own: `time.Duration(-1).Milliseconds()` truncates to `0`, so fixing only the init/reset would still print `0` in `Fields()`. Conversely, `ms()` only treats a duration as unset when it's negative, so routing `lastIdle` through `ms()` without also changing its zero-valued default would still print `0`. Only the pair produces the expected `-1`.

## Tests

Added coverage in `pkg/fetcher/trace_test.go` that isolates this behavior directly:
- A collector that never instrumented a request, and a fresh (non-reused) dial, both report `last_conn_idle_ms=-1`.
- A reused connection with a genuinely zero idle time still reports `0` — the regression case the fix has to preserve, since that's what distinguishes "measured and zero" from "never measured."
- Extended the existing real-request tests to assert on this field now that it carries meaning on the non-reused path, and corrected one existing assertion that expected the old, incorrect `0` after a connection reset.

Pure observability fix — no change to fetch behavior, timeouts, or the connection pool.